### PR TITLE
postgresql storage provider

### DIFF
--- a/actors/providers/postgresql/pom.xml
+++ b/actors/providers/postgresql/pom.xml
@@ -29,65 +29,43 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.ea.orbit</groupId>
-        <artifactId>orbit-parent</artifactId>
+        <artifactId>orbit-actors-parent</artifactId>
         <version>0.1.2-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../..</relativePath>
     </parent>
-    <groupId>com.ea.orbit</groupId>
-    <artifactId>orbit-actors-parent</artifactId>
-    <packaging>pom</packaging>
-    <name>Orbit Actors</name>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Orbit Actors Storage Provider PostgreSQL</name>
 
-    <modules>
-        <module>core</module>
-        <module>core/processor</module>
-        <module>stage</module>
-        <module>client</module>
-        <module>server</module>
-        <module>providers/json</module>
-        <module>providers/mongodb</module>
-        <module>providers/postgresql</module>
-        <module>samples</module>
-        <module>test/actor-tests</module>
-        <module>actors-all</module>
-    </modules>
-
-
-    <properties>
-        <project.target.jdk>1.8</project.target.jdk>
-        <project.source.jdk>1.8</project.source.jdk>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <target>${project.target.jdk}</target>
-                    <source>${project.source.jdk}</source>
-                </configuration>
-                <version>3.1</version>
-            </plugin>
-        </plugins>
-    </build>
+    <artifactId>orbit-actors-postgresql</artifactId>
 
     <dependencies>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>9.4-1201-jdbc41</version>
+        </dependency>
+        <dependency>
             <groupId>com.ea.orbit</groupId>
-            <artifactId>orbit-commons</artifactId>
+            <artifactId>orbit-actors-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ea.orbit</groupId>
-            <artifactId>orbit-container</artifactId>
+            <artifactId>orbit-actors-json</artifactId>
             <version>${project.version}</version>
-            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.4.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/actors/providers/postgresql/src/main/java/com/ea/orbit/actors/providers/postgresql/PostgreSQLStorageModule.java
+++ b/actors/providers/postgresql/src/main/java/com/ea/orbit/actors/providers/postgresql/PostgreSQLStorageModule.java
@@ -1,0 +1,34 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.postgresql;
+
+import com.ea.orbit.container.Module;
+
+public class PostgreSQLStorageModule extends Module {
+}

--- a/actors/providers/postgresql/src/main/java/com/ea/orbit/actors/providers/postgresql/PostgreSQLStorageProvider.java
+++ b/actors/providers/postgresql/src/main/java/com/ea/orbit/actors/providers/postgresql/PostgreSQLStorageProvider.java
@@ -57,28 +57,28 @@ public class PostgreSQLStorageProvider implements IStorageProvider {
 
     private ObjectMapper mapper;
 
-    public void setHost(String host) {
+    public void setHost(final String host) {
         this.host = host;
     }
 
-    public void setPort(int port) {
+    public void setPort(final int port) {
         this.port = port;
     }
 
-    public void setDatabase(String database) {
+    public void setDatabase(final String database) {
         this.database = database;
     }
 
-    public void setUsername(String username) {
+    public void setUsername(final String username) {
         this.username = username;
     }
 
-    public void setPassword(String password) {
+    public void setPassword(final String password) {
         this.password = password;
     }
 
     @Override
-    public synchronized Task<Void> clearState(ActorReference reference, Object state) {
+    public synchronized Task<Void> clearState(final ActorReference reference, final Object state) {
         try {
             clearState.setString(1, getName(reference));
             clearState.setString(2, getIdentity(reference));
@@ -90,7 +90,7 @@ public class PostgreSQLStorageProvider implements IStorageProvider {
     }
 
     @Override
-    public synchronized Task<Boolean> readState(ActorReference reference, Object state) {
+    public synchronized Task<Boolean> readState(final ActorReference reference, final Object state) {
         String actor = getName(reference), identity = getIdentity(reference);
         try {
             readState.setString(1, actor);
@@ -109,7 +109,7 @@ public class PostgreSQLStorageProvider implements IStorageProvider {
     }
 
     @Override
-    public synchronized Task<Void> writeState(ActorReference reference, Object state) {
+    public synchronized Task<Void> writeState(final ActorReference reference, final Object state) {
         String actor = getName(reference), identity = getIdentity(reference);
         try {
             String serializedState = mapper.writeValueAsString(state);
@@ -214,11 +214,11 @@ public class PostgreSQLStorageProvider implements IStorageProvider {
         return String.format("jdbc:postgresql://%s:%d/%s", host, port, database);
     }
 
-    private String getName(ActorReference reference) {
+    private String getName(final ActorReference reference) {
         return ActorReference.getInterfaceClass(reference).getSimpleName();
     }
 
-    private String getIdentity(ActorReference reference) {
+    private String getIdentity(final ActorReference reference) {
         return String.valueOf(ActorReference.getId(reference));
     }
 }

--- a/actors/providers/postgresql/src/main/java/com/ea/orbit/actors/providers/postgresql/PostgreSQLStorageProvider.java
+++ b/actors/providers/postgresql/src/main/java/com/ea/orbit/actors/providers/postgresql/PostgreSQLStorageProvider.java
@@ -1,0 +1,224 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.postgresql;
+
+import com.ea.orbit.actors.providers.IStorageProvider;
+import com.ea.orbit.actors.providers.json.ActorReferenceModule;
+import com.ea.orbit.actors.providers.json.ReflectionReferenceFactory;
+import com.ea.orbit.actors.runtime.ActorReference;
+import com.ea.orbit.concurrent.Task;
+import com.ea.orbit.exception.UncheckedException;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.sql.*;
+
+public class PostgreSQLStorageProvider implements IStorageProvider {
+
+    private String host = "localhost";
+    private int port = 5432; // PostgreSQL standard port
+    private String database;
+    private String username;
+    private String password;
+
+    private Connection conn;
+    private PreparedStatement insertState;
+    private PreparedStatement updateState;
+    private PreparedStatement readState;
+    private PreparedStatement clearState;
+
+    private ObjectMapper mapper;
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public synchronized Task<Void> clearState(ActorReference reference, Object state) {
+        try {
+            clearState.setString(1, getName(reference));
+            clearState.setString(2, getIdentity(reference));
+            clearState.execute();
+            return Task.done();
+        } catch(SQLException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    @Override
+    public synchronized Task<Boolean> readState(ActorReference reference, Object state) {
+        String actor = getName(reference), identity = getIdentity(reference);
+        try {
+            readState.setString(1, actor);
+            readState.setString(2, identity);
+            ResultSet results = readState.executeQuery();
+            if (results.next()) {
+                String json = results.getString("state");
+                mapper.readerForUpdating(state).readValue(json);
+                results.close();
+                return Task.fromValue(true);
+            } else
+                return Task.fromValue(false);
+        } catch(SQLException | IOException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    @Override
+    public synchronized Task<Void> writeState(ActorReference reference, Object state) {
+        String actor = getName(reference), identity = getIdentity(reference);
+        try {
+            String serializedState = mapper.writeValueAsString(state);
+            updateState.setString(1, serializedState);
+            updateState.setString(2, actor);
+            updateState.setString(3, identity);
+            if (updateState.executeUpdate() < 1) {
+                insertState.setString(1, actor);
+                insertState.setString(2, identity);
+                insertState.setString(3, serializedState);
+                insertState.execute();
+            }
+            return Task.done();
+        } catch(SQLException | JsonProcessingException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    @Override
+    public Task start() {
+        // initialize DB connection
+        loadDriver();
+        openConn();
+        prepareStatements();
+        createTableIfNotExists();
+
+        // initialize JSON mapper
+        mapper = new ObjectMapper();
+        mapper.registerModule(new ActorReferenceModule(new ReflectionReferenceFactory()));
+        mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+
+        return Task.done();
+    }
+
+    @Override
+    public Task stop() {
+        try {
+            this.conn.close();
+            return Task.done();
+        } catch (SQLException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    private void loadDriver() {
+        try {
+            Class.forName("org.postgresql.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    private void openConn() {
+        try {
+            this.conn = DriverManager.getConnection(toConnString(), username, password);
+        } catch (SQLException e) {
+            throw new UncheckedException("open connection to postgres failed", e);
+        }
+    }
+
+    private void createTableIfNotExists() {
+        if(!tableExists()) {
+            try {
+                Statement stmt = this.conn.createStatement();
+                stmt.execute("CREATE TABLE actor_states ( actor text NOT NULL, identity text NOT NULL, state text NOT NULL, PRIMARY KEY (actor, identity) )");
+                stmt.close();
+            } catch(SQLException e) {
+                throw new UncheckedException(e);
+            }
+        }
+    }
+
+    private boolean tableExists() {
+        try {
+            Statement stmt = this.conn.createStatement();
+            ResultSet results = stmt.executeQuery(
+                    "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'actor_states')");
+            boolean exists = results.next() && results.getBoolean(1);
+            stmt.close();
+            return exists;
+        } catch(SQLException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    private void prepareStatements() {
+        try {
+            this.insertState = this.conn.prepareCall("INSERT INTO actor_states (actor, identity, state) VALUES (?, ?, ?)");
+            this.updateState = this.conn.prepareCall("UPDATE actor_states SET state = ? WHERE actor = ? AND identity = ?");
+            this.readState = this.conn.prepareCall("SELECT state AS \"state\" FROM actor_states WHERE actor = ?  AND identity = ?");
+            this.clearState = this.conn.prepareCall("DELETE FROM actor_states WHERE actor = ? AND identity = ?");
+        } catch(SQLException e) {
+            throw new UncheckedException(e);
+        }
+    }
+
+    private String toConnString() {
+        return String.format("jdbc:postgresql://%s:%d/%s", host, port, database);
+    }
+
+    private String getName(ActorReference reference) {
+        return ActorReference.getInterfaceClass(reference).getSimpleName();
+    }
+
+    private String getIdentity(ActorReference reference) {
+        return String.valueOf(ActorReference.getId(reference));
+    }
+}

--- a/actors/providers/postgresql/src/test/java/com/ea/orbit/actors/providers/postgresql/test/HelloActor.java
+++ b/actors/providers/postgresql/src/test/java/com/ea/orbit/actors/providers/postgresql/test/HelloActor.java
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.postgresql.test;
+
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.concurrent.Task;
+
+public class HelloActor extends OrbitActor<HelloActor.State> implements IHelloActor {
+    public static class State {
+        String lastName;
+
+        String getLastName() {
+            return lastName;
+        }
+
+        void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+
+    }
+    @Override
+    public Task<String> sayHello(String name) {
+        state().lastName = name;
+        writeState().join();
+        return Task.fromValue("Hello " + name);
+    }
+    @Override
+    public Task<Void> clear() {
+        clearState().join();
+        return Task.done();
+    }
+}

--- a/actors/providers/postgresql/src/test/java/com/ea/orbit/actors/providers/postgresql/test/IHelloActor.java
+++ b/actors/providers/postgresql/src/test/java/com/ea/orbit/actors/providers/postgresql/test/IHelloActor.java
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.postgresql.test;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.concurrent.Task;
+
+public interface IHelloActor extends IActor {
+    Task<String> sayHello(String name);
+    Task<Void> clear();
+}

--- a/actors/providers/postgresql/src/test/java/com/ea/orbit/actors/providers/postgresql/test/PostgreSQLPersistenceTest.java
+++ b/actors/providers/postgresql/src/test/java/com/ea/orbit/actors/providers/postgresql/test/PostgreSQLPersistenceTest.java
@@ -1,0 +1,142 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.postgresql.test;
+
+import com.ea.orbit.actors.OrbitStage;
+import com.ea.orbit.actors.providers.postgresql.PostgreSQLStorageProvider;
+import com.ea.orbit.actors.test.FakeClusterPeer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgreSQLPersistenceTest {
+
+    private String clusterName = "cluster." + Math.random();
+    private Connection conn;
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void checkWritesTest() throws Exception {
+        OrbitStage stage = createStage();
+        assertEquals(0, count(IHelloActor.class));
+        IHelloActor helloActor = stage.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count(IHelloActor.class));
+    }
+
+    @Test
+    public void checkReadTest() throws Exception {
+        OrbitStage stage = createStage();
+        IHelloActor helloActor = stage.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(readHelloState("300").lastName, "Meep Meep");
+    }
+
+    @Test
+    public void checkClearTest() throws Exception {
+        OrbitStage stage = createStage();
+        assertEquals(0, count(IHelloActor.class));
+        IHelloActor helloActor = stage.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count(IHelloActor.class));
+        helloActor.clear().join();
+        assertEquals(0, count(IHelloActor.class));
+    }
+
+    @Test
+    public void checkUpdateTest() throws Exception {
+        OrbitStage stage = createStage();
+        assertEquals(0, count(IHelloActor.class));
+        IHelloActor helloActor = stage.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count(IHelloActor.class));
+        helloActor.sayHello("Peem Peem").join();
+        assertEquals(readHelloState("300").lastName, "Peem Peem");
+    }
+
+    public OrbitStage createStage() throws Exception {
+        OrbitStage stage = new OrbitStage();
+        final PostgreSQLStorageProvider storageProvider = new PostgreSQLStorageProvider();
+        storageProvider.setPort(5433);
+        storageProvider.setDatabase("orbit");
+        storageProvider.setUsername("orbit");
+        storageProvider.setPassword("secret");
+        stage.addProvider(storageProvider);
+        stage.setClusterName(clusterName);
+        stage.setClusterPeer(new FakeClusterPeer());
+        stage.start().get();
+
+        return stage;
+    }
+
+    @Before
+    public void setup() throws Exception {
+        Class.forName("org.postgresql.Driver");
+        this.conn = DriverManager.getConnection("jdbc:postgresql://localhost:5433/orbit", "orbit", "secret");
+        this.objectMapper =  new ObjectMapper();
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        Statement dropStmt = this.conn.createStatement();
+        dropStmt.execute("DROP TABLE actor_states");
+        dropStmt.close();
+        this.conn.close();
+    }
+
+    private int count(Class<?> actorInterface) throws Exception {
+        Statement stmt = this.conn.createStatement();
+        String name = actorInterface.getSimpleName();
+        ResultSet results = stmt.executeQuery("SELECT COUNT(*) AS \"cnt\" FROM actor_states WHERE actor = '" + name + "'");
+        results.next();
+        int count = results.getInt("cnt");
+        stmt.close();
+        return count;
+    }
+
+    private HelloActor.State readHelloState(String identity) throws Exception {
+        Statement stmt = this.conn.createStatement();
+        ResultSet results = stmt.executeQuery(
+                "SELECT state AS \"state\" FROM actor_states WHERE actor = '" + IHelloActor.class.getSimpleName()
+                        + "' AND identity = '" + identity + "'");
+        results.next();
+        HelloActor.State state = objectMapper.readValue(results.getString("state"), HelloActor.State.class);
+        stmt.close();
+        return state;
+    }
+
+}


### PR DESCRIPTION
These commits add a new storage provider module for postgresql.
I tried to adopt as much from the mongodb implementation as possible, the only referenced I used.

Only requires one table in the specified database:
```sql
CREATE TABLE actor_sates (
   actor text NOT NULL,
   identity text NOT NULL,
   state text NOT NULL,
   PRIMARY KEY (actor, identity)
);
```
If the table does not exist the provider tries to perform a create statement.
The `state` column contains the specific actors state serialized in JSON.

Usage:
```java
OrbitStage stage = new OrbitStage();
final PostgreSQLStorageProvider storageProvider = new PostgreSQLStorageProvider();
storageProvider.setHost("localhost");
storageProvider.setPort(5433);
storageProvider.setDatabase("orbit");
storageProvider.setUsername("orbit");
storageProvider.setPassword("secret");
stage.addProvider(storageProvider);
// ...
```

Reading, writing, updating and clearing state are implemented & tested.