### PR TITLE
Added First JpaStorageProvider implementation

### DIFF
--- a/actors/providers/jpa/README.md
+++ b/actors/providers/jpa/README.md
@@ -1,0 +1,19 @@
+JPA Storage Provider
+============
+
+This provider materializes states in relational databases.
+
+Requirements
+=======
+
+- The states cant be inner classes
+- The states must extend JpaState.class
+- The states must have the @Entity annotation
+- States classes should not be shared between Actors, each one must have its own
+
+Note: All requirements dont affect others storage providers.
+
+Tables
+=======
+
+Tables are automatically created, and the jpa ddl strategy at the persistence.xml defines if the tables will be updated when a new field is created.

--- a/actors/providers/jpa/pom.xml
+++ b/actors/providers/jpa/pom.xml
@@ -29,65 +29,60 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.ea.orbit</groupId>
-        <artifactId>orbit-parent</artifactId>
+        <artifactId>orbit-actors-parent</artifactId>
         <version>0.2.1-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../..</relativePath>
     </parent>
-    <artifactId>orbit-actors-parent</artifactId>
-    <packaging>pom</packaging>
-    <name>Orbit Actors</name>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Orbit Actors Storage Provider PostgreSQL</name>
 
-    <modules>
-        <module>core</module>
-        <module>stage</module>
-        <module>client</module>
-        <module>server</module>
-		<module>providers/jpa</module>
-        <module>providers/json</module>
-        <module>providers/mongodb</module>
-		<module>providers/redis</module>
-        <module>providers/postgresql</module>
-        <module>providers/spring</module>
-        <module>test/actor-tests</module>
-        <module>actors-all</module>
-    </modules>
-
+    <artifactId>orbit-actors-jpa</artifactId>
 
     <properties>
-        <project.target.jdk>1.8</project.target.jdk>
-        <project.source.jdk>1.8</project.source.jdk>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.test.skip>true</maven.test.skip>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <target>${project.target.jdk}</target>
-                    <source>${project.source.jdk}</source>
-                </configuration>
-                <version>3.1</version>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>withJpaTests</id>
+            <properties>
+                <maven.test.skip>false</maven.test.skip>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.35</version>
+        </dependency>
+
+
         <dependency>
             <groupId>com.ea.orbit</groupId>
-            <artifactId>orbit-commons</artifactId>
+            <artifactId>orbit-actors-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.ea.orbit</groupId>
-            <artifactId>orbit-container</artifactId>
+            <artifactId>orbit-actors-json</artifactId>
             <version>${project.version}</version>
-            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaState.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaState.java
@@ -1,0 +1,11 @@
+package com.ea.orbit.actors.providers.jpa;
+
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
+@MappedSuperclass
+public abstract class JpaState
+{
+    @Id
+    protected String stateId;
+}

--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageModule.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageModule.java
@@ -1,0 +1,35 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.jpa;
+
+import com.ea.orbit.container.Module;
+
+public class JpaStorageModule extends Module
+{
+}

--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
@@ -1,0 +1,161 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.jpa;
+
+import com.ea.orbit.actors.providers.IStorageProvider;
+import com.ea.orbit.actors.runtime.ActorReference;
+import com.ea.orbit.concurrent.Task;
+import com.ea.orbit.exception.UncheckedException;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+
+public class JpaStorageProvider implements IStorageProvider
+{
+
+    private String persistenceUnitName = "jp-storage-production";
+
+    private EntityManagerFactory emf;
+    private ObjectMapper mapper;
+
+
+    public void setPersistenceUnit(final String name)
+    {
+        persistenceUnitName = name;
+    }
+
+    @Override
+    public synchronized Task<Void> clearState(final ActorReference<?> reference, final Object state)
+    {
+        try
+        {
+            EntityManager em = emf.createEntityManager();
+            Query query = em.createQuery("delete from " + state.getClass().getSimpleName());
+            em.getTransaction().begin();
+            query.executeUpdate();
+            em.getTransaction().commit();
+            em.close();
+            return Task.done();
+        }
+        catch (Exception e)
+        {
+            throw new UncheckedException(e);
+        }
+    }
+
+    @Override
+    public synchronized Task<Boolean> readState(final ActorReference<?> reference, final Object state)
+    {
+        try
+        {
+            String stateId = getIdentity(reference);
+            EntityManager em = emf.createEntityManager();
+            Query query = em.createQuery("select s from " + state.getClass().getSimpleName() + " s where s.stateId=:stateId");
+            query.setParameter("stateId", stateId);
+            Object newState;
+            try
+            {
+                newState = query.getSingleResult();
+            }
+            catch (NoResultException e)
+            {
+                newState = state.getClass().newInstance();
+            }
+            mapper.readerForUpdating(state).readValue(mapper.writeValueAsString(newState));
+            em.close();
+            return Task.fromValue(true);
+        }
+        catch (Exception e)
+        {
+            throw new UncheckedException(e);
+        }
+
+    }
+
+    @Override
+    public synchronized Task<Void> writeState(final ActorReference<?> reference, final Object state)
+    {
+        String identity = getIdentity(reference);
+        JpaState jpaState = (JpaState) state;
+        jpaState.stateId = identity;
+        try
+        {
+            EntityManager em = emf.createEntityManager();
+            em.getTransaction().begin();
+            em.merge(state);
+            em.getTransaction().commit();
+            em.detach(state);
+            em.close();
+            return Task.done();
+        }
+        catch (Exception e)
+        {
+            throw new UncheckedException(e);
+        }
+    }
+
+    @Override
+    public Task<Void> start()
+    {
+        emf = Persistence.createEntityManagerFactory(persistenceUnitName);
+        mapper = new ObjectMapper();
+        mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+
+        return Task.done();
+    }
+
+    @Override
+    public Task<Void> stop()
+    {
+        try
+        {
+            emf.close();
+            return Task.done();
+        }
+        catch (Exception e)
+        {
+            throw new UncheckedException(e);
+        }
+    }
+
+    private String getIdentity(final ActorReference<?> reference)
+    {
+        return String.valueOf(ActorReference.getId(reference));
+    }
+}

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/HelloActor.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/HelloActor.java
@@ -1,0 +1,51 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.jpa.test;
+
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.concurrent.Task;
+
+public class HelloActor extends OrbitActor<HelloState> implements IHelloActor
+{
+
+    @Override
+    public Task<String> sayHello(String name)
+    {
+        state().lastName = name;
+        writeState().join();
+        return Task.fromValue("Hello " + name);
+    }
+
+    @Override
+    public Task<Void> clear()
+    {
+        clearState().join();
+        return Task.done();
+    }
+}

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/HelloState.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/HelloState.java
@@ -1,0 +1,14 @@
+package com.ea.orbit.actors.providers.jpa.test;
+
+import com.ea.orbit.actors.providers.jpa.JpaState;
+
+import javax.persistence.Entity;
+
+@Entity
+public class HelloState extends JpaState
+{
+
+    public String lastName;
+
+
+}

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/IHelloActor.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/IHelloActor.java
@@ -1,0 +1,39 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.jpa.test;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.concurrent.Task;
+
+public interface IHelloActor extends IActor
+{
+    Task<String> sayHello(String name);
+
+    Task<Void> clear();
+}

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/JpaPersistenceTest.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/JpaPersistenceTest.java
@@ -1,0 +1,152 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.providers.jpa.test;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.OrbitStage;
+import com.ea.orbit.actors.providers.jpa.JpaStorageProvider;
+import com.ea.orbit.actors.test.FakeClusterPeer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("unused")
+public class JpaPersistenceTest
+{
+
+    private String clusterName = "cluster." + Math.random();
+    private ObjectMapper objectMapper;
+    private EntityManagerFactory emf;
+
+    @Test
+    public void checkWritesTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count(IHelloActor.class));
+        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count(IHelloActor.class));
+    }
+
+    @Test
+    public void checkReadTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(readHelloState("300").lastName, "Meep Meep");
+    }
+
+    @Test
+    public void checkClearTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count(IHelloActor.class));
+        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count(IHelloActor.class));
+        helloActor.clear().join();
+        assertEquals(0, count(IHelloActor.class));
+    }
+
+    @Test
+    public void checkUpdateTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count(IHelloActor.class));
+        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count(IHelloActor.class));
+        helloActor.sayHello("Peem Peem").join();
+        assertEquals(readHelloState("300").lastName, "Peem Peem");
+    }
+
+    public OrbitStage createStage() throws Exception
+    {
+        OrbitStage stage = new OrbitStage();
+        final JpaStorageProvider storageProvider = new JpaStorageProvider();
+        storageProvider.setPersistenceUnit("jpa-storage-test");
+        stage.addProvider(storageProvider);
+        stage.setClusterName(clusterName);
+        stage.setClusterPeer(new FakeClusterPeer());
+        stage.start().get();
+        stage.bind();
+        return stage;
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @After
+    public void cleanup() throws Exception
+    {
+        emf = Persistence.createEntityManagerFactory("jpa-storage-test");
+        EntityManager em = emf.createEntityManager();
+        Query query = em.createQuery("delete from " + HelloState.class.getSimpleName());
+        em.getTransaction().begin();
+        query.executeUpdate();
+        em.getTransaction().commit();
+        em.close();
+    }
+
+    private long count(Class<?> actorInterface) throws Exception
+    {
+        emf = Persistence.createEntityManagerFactory("jpa-storage-test");
+        EntityManager em = emf.createEntityManager();
+        Query query = em.createQuery("select count(s) from " + HelloState.class.getSimpleName() + " s");
+        long count = (long) query.getSingleResult();
+        em.close();
+        return count;
+    }
+
+    private HelloState readHelloState(String identity) throws Exception
+    {
+        emf = Persistence.createEntityManagerFactory("jpa-storage-test");
+        EntityManager em = emf.createEntityManager();
+        Query query = em.createQuery("select s from " + HelloState.class.getSimpleName() + " s where s.stateId=:stateId");
+        query.setParameter("stateId", identity);
+        HelloState state = (HelloState) query.getSingleResult();
+        em.close();
+        return state;
+    }
+
+}

--- a/actors/providers/jpa/src/test/resources/META-INF/persistence.xml
+++ b/actors/providers/jpa/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="1.0" xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+
+    <persistence-unit name="jpa-storage-test" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.jdbc.password" value="123456"/>
+            <property name="eclipselink.jdbc.user" value="root"/>
+            <property name="eclipselink.jdbc.driver" value="com.mysql.jdbc.Driver"/>
+            <property name="eclipselink.jdbc.url" value="jdbc:mysql://127.0.0.1:3306/test"/>
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+            <property name="eclipselink.logging.level" value="INFO"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="jpa-storage-production" transaction-type="RESOURCE_LOCAL">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.jdbc.password" value="123456"/>
+            <property name="eclipselink.jdbc.user" value="root"/>
+            <property name="eclipselink.jdbc.driver" value="com.mysql.jdbc.Driver"/>
+            <property name="eclipselink.jdbc.url" value="jdbc:mysql://127.0.0.1:3306/test"/>
+            <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
+            <property name="eclipselink.logging.level" value="INFO"/>
+        </properties>
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
JPA Storage Provider
============

This provider materializes states in relational databases.

Requirements
=======

- The states cant be inner classes
- The states must extend JpaState.class
- The states must have the @Entity annotation
- States classes should not be shared between Actors, each one must have its own

Note: All requirements dont affect others storage providers.

Tables
=======

Tables are automatically created, and the jpa ddl strategy at the persistence.xml defines if the tables will be updated when a new field is created.