### PR TITLE
Fixed jpa clearState()

### DIFF
--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
@@ -61,8 +61,10 @@ public class JpaStorageProvider implements IStorageProvider
     {
         try
         {
+            String stateId = getIdentity(reference);
             EntityManager em = emf.createEntityManager();
-            Query query = em.createQuery("delete from " + state.getClass().getSimpleName());
+            Query query = em.createQuery("delete from " + state.getClass().getSimpleName() + " s where s.stateId=:stateId");
+            query.setParameter("stateId", stateId);
             em.getTransaction().begin();
             query.executeUpdate();
             em.getTransaction().commit();

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/JpaPersistenceTest.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/JpaPersistenceTest.java
@@ -78,10 +78,14 @@ public class JpaPersistenceTest
     {
         OrbitStage stage = createStage();
         assertEquals(0, count(IHelloActor.class));
-        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
-        helloActor.sayHello("Meep Meep").join();
+        IHelloActor helloActor1 = IActor.getReference(IHelloActor.class, "300");
+        helloActor1.sayHello("Meep Meep").join();
+        IHelloActor helloActor2 = IActor.getReference(IHelloActor.class, "301");
+        helloActor2.sayHello("Meep Meep").join();
+        assertEquals(2, count(IHelloActor.class));
+        helloActor1.clear().join();
         assertEquals(1, count(IHelloActor.class));
-        helloActor.clear().join();
+        helloActor2.clear().join();
         assertEquals(0, count(IHelloActor.class));
     }
 


### PR DESCRIPTION
Fixed ClearState behaviour. We should improve and normalize all storage tests. They are not even testing the contents of the persisted data.