### PR TITLE
Added StorageBaseTest and unified redis and jpa tests

### DIFF
--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/HelloState.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/HelloState.java
@@ -1,14 +1,48 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 package com.ea.orbit.actors.providers.jpa.test;
 
 import com.ea.orbit.actors.providers.jpa.JpaState;
+import com.ea.orbit.actors.test.IStorageTestState;
 
 import javax.persistence.Entity;
 
 @Entity
-public class HelloState extends JpaState
+public class HelloState extends JpaState implements IStorageTestState
 {
 
     public String lastName;
 
 
+    @Override
+    public String lastName()
+    {
+        return lastName;
+    }
 }

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/IHelloActor.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/IHelloActor.java
@@ -29,11 +29,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.ea.orbit.actors.providers.jpa.test;
 
 import com.ea.orbit.actors.IActor;
-import com.ea.orbit.concurrent.Task;
+import com.ea.orbit.actors.test.IStorageTestActor;
 
-public interface IHelloActor extends IActor
+public interface IHelloActor extends IActor, IStorageTestActor
 {
-    Task<String> sayHello(String name);
-
-    Task<Void> clear();
+    //basic tasks from IStorageTestActor interface
 }

--- a/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/JpaPersistenceTest.java
+++ b/actors/providers/jpa/src/test/java/com/ea/orbit/actors/providers/jpa/test/JpaPersistenceTest.java
@@ -28,100 +28,39 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.ea.orbit.actors.providers.jpa.test;
 
-import com.ea.orbit.actors.IActor;
-import com.ea.orbit.actors.OrbitStage;
+import com.ea.orbit.actors.providers.IOrbitProvider;
 import com.ea.orbit.actors.providers.jpa.JpaStorageProvider;
-import com.ea.orbit.actors.test.FakeClusterPeer;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ea.orbit.actors.test.IStorageTestActor;
+import com.ea.orbit.actors.test.IStorageTestState;
+import com.ea.orbit.actors.test.StorageBaseTest;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.persistence.Query;
 
-import static org.junit.Assert.assertEquals;
-
 @SuppressWarnings("unused")
-public class JpaPersistenceTest
+public class JpaPersistenceTest extends StorageBaseTest
 {
 
-    private String clusterName = "cluster." + Math.random();
-    private ObjectMapper objectMapper;
     private EntityManagerFactory emf;
 
-    @Test
-    public void checkWritesTest() throws Exception
+    @Override
+    public Class<? extends IStorageTestActor> getActorInterfaceClass()
     {
-        OrbitStage stage = createStage();
-        assertEquals(0, count(IHelloActor.class));
-        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
-        helloActor.sayHello("Meep Meep").join();
-        assertEquals(1, count(IHelloActor.class));
+        return IHelloActor.class;
     }
 
-    @Test
-    public void checkReadTest() throws Exception
+    @Override
+    public IOrbitProvider getStorageProvider()
     {
-        OrbitStage stage = createStage();
-        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
-        helloActor.sayHello("Meep Meep").join();
-        assertEquals(readHelloState("300").lastName, "Meep Meep");
-    }
-
-    @Test
-    public void checkClearTest() throws Exception
-    {
-        OrbitStage stage = createStage();
-        assertEquals(0, count(IHelloActor.class));
-        IHelloActor helloActor1 = IActor.getReference(IHelloActor.class, "300");
-        helloActor1.sayHello("Meep Meep").join();
-        IHelloActor helloActor2 = IActor.getReference(IHelloActor.class, "301");
-        helloActor2.sayHello("Meep Meep").join();
-        assertEquals(2, count(IHelloActor.class));
-        helloActor1.clear().join();
-        assertEquals(1, count(IHelloActor.class));
-        helloActor2.clear().join();
-        assertEquals(0, count(IHelloActor.class));
-    }
-
-    @Test
-    public void checkUpdateTest() throws Exception
-    {
-        OrbitStage stage = createStage();
-        assertEquals(0, count(IHelloActor.class));
-        IHelloActor helloActor = IActor.getReference(IHelloActor.class, "300");
-        helloActor.sayHello("Meep Meep").join();
-        assertEquals(1, count(IHelloActor.class));
-        helloActor.sayHello("Peem Peem").join();
-        assertEquals(readHelloState("300").lastName, "Peem Peem");
-    }
-
-    public OrbitStage createStage() throws Exception
-    {
-        OrbitStage stage = new OrbitStage();
         final JpaStorageProvider storageProvider = new JpaStorageProvider();
         storageProvider.setPersistenceUnit("jpa-storage-test");
-        stage.addProvider(storageProvider);
-        stage.setClusterName(clusterName);
-        stage.setClusterPeer(new FakeClusterPeer());
-        stage.start().get();
-        stage.bind();
-        return stage;
+        return storageProvider;
     }
 
-    @Before
-    public void setup() throws Exception
-    {
-        this.objectMapper = new ObjectMapper();
-    }
-
-    @After
-    public void cleanup() throws Exception
+    @Override
+    public void initStorage()
     {
         emf = Persistence.createEntityManagerFactory("jpa-storage-test");
         EntityManager em = emf.createEntityManager();
@@ -132,7 +71,19 @@ public class JpaPersistenceTest
         em.close();
     }
 
-    private long count(Class<?> actorInterface) throws Exception
+    @Override
+    public void closeStorage()
+    {
+        EntityManager em = emf.createEntityManager();
+        Query query = em.createQuery("delete from " + HelloState.class.getSimpleName());
+        em.getTransaction().begin();
+        query.executeUpdate();
+        em.getTransaction().commit();
+        em.close();
+        emf.close();
+    }
+
+    public long count()
     {
         emf = Persistence.createEntityManagerFactory("jpa-storage-test");
         EntityManager em = emf.createEntityManager();
@@ -142,7 +93,14 @@ public class JpaPersistenceTest
         return count;
     }
 
-    private HelloState readHelloState(String identity) throws Exception
+    @Override
+    public int loadTestSize()
+    {
+        return 100;
+    }
+
+    @Override
+    public IStorageTestState readState(final String identity)
     {
         emf = Persistence.createEntityManagerFactory("jpa-storage-test");
         EntityManager em = emf.createEntityManager();
@@ -152,5 +110,6 @@ public class JpaPersistenceTest
         em.close();
         return state;
     }
+
 
 }

--- a/actors/providers/jpa/src/test/resources/META-INF/persistence.xml
+++ b/actors/providers/jpa/src/test/resources/META-INF/persistence.xml
@@ -7,10 +7,10 @@
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.jdbc.password" value="123456"/>
-            <property name="eclipselink.jdbc.user" value="root"/>
-            <property name="eclipselink.jdbc.driver" value="com.mysql.jdbc.Driver"/>
-            <property name="eclipselink.jdbc.url" value="jdbc:mysql://127.0.0.1:3306/test"/>
+            <property name="javax.persistence.jdbc.password" value="123456"/>
+            <property name="javax.persistence.jdbc.user" value="root"/>
+            <property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://127.0.0.1:3306/test"/>
             <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
             <property name="eclipselink.logging.level" value="INFO"/>
         </properties>
@@ -20,10 +20,10 @@
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="eclipselink.jdbc.password" value="123456"/>
-            <property name="eclipselink.jdbc.user" value="root"/>
-            <property name="eclipselink.jdbc.driver" value="com.mysql.jdbc.Driver"/>
-            <property name="eclipselink.jdbc.url" value="jdbc:mysql://127.0.0.1:3306/test"/>
+            <property name="javax.persistence.jdbc.password" value="123456"/>
+            <property name="javax.persistence.jdbc.user" value="root"/>
+            <property name="javax.persistence.jdbc.driver" value="com.mysql.jdbc.Driver"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://127.0.0.1:3306/test"/>
             <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
             <property name="eclipselink.logging.level" value="INFO"/>
         </properties>

--- a/actors/providers/redis/src/main/java/com/ea/orbit/actors/providers/redis/RedisStorageProvider.java
+++ b/actors/providers/redis/src/main/java/com/ea/orbit/actors/providers/redis/RedisStorageProvider.java
@@ -60,13 +60,14 @@ public class RedisStorageProvider implements IStorageProvider {
 				.withFieldVisibility(JsonAutoDetect.Visibility.ANY)
 				.withGetterVisibility(JsonAutoDetect.Visibility.NONE)
 				.withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+				.withSetterVisibility(JsonAutoDetect.Visibility.NONE)
 				.withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 		redis = new Jedis(host, port);
 		return Task.done();
 	}
 
 	private String asKey(final ActorReference reference) {
-		String classname = ActorReference.getInterfaceClass(reference).getSimpleName();
+		String classname = ActorReference.getInterfaceClass(reference).getName();
 		String id = String.valueOf(ActorReference.getId(reference));
 		return databaseName + "_" + classname + "_" + id;
 	}

--- a/actors/providers/redis/src/test/java/com/ea/orbit/actors/redis/test/HelloActor.java
+++ b/actors/providers/redis/src/test/java/com/ea/orbit/actors/redis/test/HelloActor.java
@@ -28,17 +28,24 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.ea.orbit.actors.redis.test;
 
-
-import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.runtime.OrbitActor;
 import com.ea.orbit.concurrent.Task;
 
-import java.util.List;
-
-public interface ISomeMatch extends IActor
+public class HelloActor extends OrbitActor<HelloState> implements IHelloActor
 {
-    Task<Void> addPlayer(ISomePlayer player);
 
-    Task<List<ISomePlayer>> getPlayers();
+    @Override
+    public Task<String> sayHello(String name)
+    {
+        state().lastName = name;
+        writeState().join();
+        return Task.fromValue("Hello " + name);
+    }
 
-    Task<Void> delete();
+    @Override
+    public Task<Void> clear()
+    {
+        clearState().join();
+        return Task.done();
+    }
 }

--- a/actors/providers/redis/src/test/java/com/ea/orbit/actors/redis/test/HelloState.java
+++ b/actors/providers/redis/src/test/java/com/ea/orbit/actors/redis/test/HelloState.java
@@ -1,0 +1,16 @@
+package com.ea.orbit.actors.redis.test;
+
+import com.ea.orbit.actors.test.IStorageTestState;
+
+public class HelloState implements IStorageTestState
+{
+
+    public String lastName;
+
+    @Override
+    public String lastName()
+    {
+        return lastName;
+    }
+
+}

--- a/actors/providers/redis/src/test/java/com/ea/orbit/actors/redis/test/IHelloActor.java
+++ b/actors/providers/redis/src/test/java/com/ea/orbit/actors/redis/test/IHelloActor.java
@@ -29,11 +29,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.ea.orbit.actors.redis.test;
 
 import com.ea.orbit.actors.IActor;
-import com.ea.orbit.concurrent.Task;
+import com.ea.orbit.actors.test.IStorageTestActor;
 
-public interface ISomePlayer extends IActor
+public interface IHelloActor extends IActor, IStorageTestActor
 {
-    Task<String> getName();
-
-    Task<Void> joinMatch(ISomeMatch someMatch);
+    //basic tasks from IStorageTestActor interface
 }

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/IStorageTestActor.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/IStorageTestActor.java
@@ -24,26 +24,16 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+*/
 
-package com.ea.orbit.actors.redis.test;
+package com.ea.orbit.actors.test;
 
-import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.actors.IActor;
 import com.ea.orbit.concurrent.Task;
 
-public class SomePlayer extends OrbitActor<SomePlayer.SomePlayerStateDto> implements ISomePlayer {
-	public static class SomePlayerStateDto {
+public interface IStorageTestActor extends IActor
+{
+    Task<String> sayHello(String name);
 
-	}
-
-	@Override
-	public Task<String> getName() {
-		return Task.fromValue(null);
-	}
-
-	@Override
-	public Task<Void> joinMatch(final ISomeMatch someMatch) {
-		return someMatch.addPlayer(this);
-	}
-
+    Task<Void> clear();
 }

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/IStorageTestState.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/IStorageTestState.java
@@ -24,34 +24,13 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+*/
 
-package com.ea.orbit.actors.redis.test;
+package com.ea.orbit.actors.test;
 
-import com.ea.orbit.actors.runtime.OrbitActor;
-import com.ea.orbit.concurrent.Task;
+public interface IStorageTestState
+{
 
-import java.util.ArrayList;
-import java.util.List;
+    String lastName();
 
-public class SomeMatch extends OrbitActor<SomeMatch.SomeMatchDto> implements ISomeMatch {
-	public static class SomeMatchDto {
-		private List<ISomePlayer> players = new ArrayList<>();
-	}
-
-	@Override
-	public Task<Void> addPlayer(final ISomePlayer player) {
-		state().players.add(player);
-		return writeState();
-	}
-
-	@Override
-	public Task<List<ISomePlayer>> getPlayers() {
-		return Task.fromValue(state().players);
-	}
-
-	@Override
-	public Task<Void> delete() {
-		return clearState();
-	}
 }

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/StorageBaseTest.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/StorageBaseTest.java
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.actors.test;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.OrbitStage;
+import com.ea.orbit.actors.providers.IOrbitProvider;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class StorageBaseTest
+{
+
+    private String clusterName = "cluster." + Math.random();
+
+    @Test
+    public void checkWritesTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count());
+        IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count());
+    }
+
+    @Test
+    public void loadTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count());
+        for(int t=0;t<loadTestSize();t++){
+            String id =""+t;
+            IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), id);
+            helloActor.sayHello("Meep Meep"+t).join();
+        }
+        assertEquals(loadTestSize(), count());
+        for(int t=0;t<loadTestSize();t++){
+            String id =""+t;
+            IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), id);
+            helloActor.sayHello("Meep Meep"+t).join();
+            assertEquals(readState(id).lastName(), "Meep Meep"+t);
+        }
+        for(int t=0;t<loadTestSize();t++){
+            String id =""+t;
+            IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), id);
+            helloActor.clear().join();
+        }
+        assertEquals(0, count());
+    }
+
+    @Test
+    public void checkReadTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(readState("300").lastName(), "Meep Meep");
+    }
+
+    @Test
+    public void checkClearTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count());
+        IStorageTestActor helloActor1 = IActor.getReference(getActorInterfaceClass(), "300");
+        helloActor1.sayHello("Meep Meep").join();
+        IStorageTestActor helloActor2 = IActor.getReference(getActorInterfaceClass(), "301");
+        helloActor2.sayHello("Meep Meep").join();
+        assertEquals(2, count());
+        helloActor1.clear().join();
+        assertEquals(1, count());
+        helloActor2.clear().join();
+        assertEquals(0, count());
+    }
+
+    @Test
+    public void checkUpdateTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count());
+        IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), "300");
+        helloActor.sayHello("Meep Meep").join();
+        assertEquals(1, count());
+        helloActor.sayHello("Peem Peem").join();
+        assertEquals(readState("300").lastName(), "Peem Peem");
+    }
+
+    public OrbitStage createStage() throws Exception
+    {
+        OrbitStage stage = new OrbitStage();
+        stage.addProvider(getStorageProvider());
+        stage.setClusterName(clusterName);
+        stage.setClusterPeer(new FakeClusterPeer());
+        stage.start().get();
+        stage.bind();
+        return stage;
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        initStorage();
+    }
+
+    @After
+    public void cleanup() throws Exception
+    {
+        closeStorage();
+    }
+
+    public abstract Class<? extends IStorageTestActor> getActorInterfaceClass();
+
+    public abstract IOrbitProvider getStorageProvider();
+
+    public abstract void initStorage();
+
+    public abstract void closeStorage();
+
+    public abstract long count();
+
+    public abstract int loadTestSize();
+
+    public abstract IStorageTestState readState(String identity);
+
+
+}


### PR DESCRIPTION
I created a base storage test, with the tests that should be shared and performed at all storages.
I unified the redis and the jpa example to use it.
Some minimum small changes were made to other storage classes.