### PR TITLE
Added First Actor Method Trace implementation

### DIFF
--- a/actors/core/src/main/java/com/ea/orbit/actors/providers/IInvokeListenerProvider.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/providers/IInvokeListenerProvider.java
@@ -1,0 +1,16 @@
+package com.ea.orbit.actors.providers;
+
+public interface IInvokeListenerProvider extends IOrbitProvider
+{
+
+    default void preInvoke(long traceId, String sourceInterfaceClass, String sourceId, String targetClass, String targetId, int methodId, Object[] params)
+    {
+
+    }
+
+    default void postInvoke(long traceId, Object result)
+    {
+
+    }
+
+}

--- a/actors/core/src/main/java/com/ea/orbit/actors/runtime/ActorReference.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/runtime/ActorReference.java
@@ -98,7 +98,7 @@ public abstract class ActorReference<T> implements Serializable, IAddressable
     @SuppressWarnings("unchecked")
     protected <R> Task<R> invoke(final Method method, final boolean oneWay, final int methodId, final Object[] params)
     {
-        return (Task<R>) getRuntime().invoke(this, method, oneWay, methodId, params);
+        return (Task<R>) (runtime != null ? runtime : Runtime.getRuntime()).invoke(this, method, oneWay, methodId, params);
     }
 
     @Override
@@ -188,8 +188,9 @@ public abstract class ActorReference<T> implements Serializable, IAddressable
         reference.address = nodeAddress;
     }
 
-    public IRuntime getRuntime(){
-        return (runtime != null ? runtime : Runtime.getRuntime());
+    public static ActorReference from(OrbitActor actor)
+    {
+        return actor.reference;
     }
 
 }

--- a/actors/core/src/main/java/com/ea/orbit/actors/runtime/IRuntime.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/runtime/IRuntime.java
@@ -113,4 +113,12 @@ public interface IRuntime
      */
     String runtimeIdentity();
 
+    /**
+     *
+     * @return
+     */
+    ActorReference getCurrentActivation();
+
+    long getCurrentTraceId();
+
 }

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -46,6 +46,7 @@
         <module>chat</module>
         <module>hello</module>
 		<module>memoize</module>
+		<module>trace</module>
     </modules>
 
     <profiles>

--- a/samples/trace/README.md
+++ b/samples/trace/README.md
@@ -1,0 +1,8 @@
+
+Trace Sample
+===================
+
+This is a implementation of a Actor method tracer.
+
+
+

--- a/samples/trace/graph.css
+++ b/samples/trace/graph.css
@@ -1,0 +1,26 @@
+graph {
+    fill-color: white;
+}
+
+edge {
+    arrow-shape: arrow;
+    text-background-mode: rounded-box;
+    text-color: black;
+    text-background-color: yellow;
+    text-alignment: along;
+    shape: cubic-curve;
+}
+
+node {
+    text-alignment: above;
+    text-color: white;
+    text-style: bold;
+    text-background-mode: rounded-box;
+    text-background-color: #222C;
+    text-padding: 4px, 3px;
+    text-offset: 0px, -6px;
+}
+
+node:clicked {
+    fill-color: red;
+}

--- a/samples/trace/pom.xml
+++ b/samples/trace/pom.xml
@@ -62,6 +62,17 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>xchart</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+
 
         <dependency>
             <groupId>com.ea.orbit</groupId>
@@ -80,17 +91,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <version>1.1.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.ea.orbit</groupId>
-            <artifactId>orbit-actors-tests</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ea.orbit</groupId>
-            <artifactId>orbit-actors-tests</artifactId>
-            <version>0.1.2-SNAPSHOT</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/samples/trace/pom.xml
+++ b/samples/trace/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.ea.orbit.samples</groupId>
+        <artifactId>orbit-samples-parent</artifactId>
+        <version>0.2.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Orbit Samples: Trace</name>
+    <artifactId>orbit-samples-trace</artifactId>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.graphstream</groupId>
+            <artifactId>gs-core</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graphstream</groupId>
+            <artifactId>gs-algo</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graphstream</groupId>
+            <artifactId>gs-ui</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.xeiam.xchart</groupId>
+            <artifactId>xchart</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-stage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-tests</artifactId>
+            <version>0.1.2-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.3.2</version>
+                <configuration>
+                    <mainClass>com.ea.orbit.samples.memoize.Main</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/ExampleA.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/ExampleA.java
@@ -1,0 +1,66 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.demo;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.actors.runtime.Registration;
+import com.ea.orbit.concurrent.Task;
+
+import java.util.concurrent.TimeUnit;
+
+public class ExampleA extends OrbitActor implements IExampleA
+{
+
+    Registration timer;
+
+    @Override
+    public Task activateAsync()
+    {
+        int interval = 100 + ((int) Math.random() * 3000);
+        timer = registerTimer(() -> callRandomB(), interval, interval, TimeUnit.MILLISECONDS);
+        return super.activateAsync();
+    }
+
+    @Override
+    public Task<Void> callRandomB()
+    {
+        if (Math.random() > 0.5d) return Task.done(); //some variance to the calls
+        String id = Integer.toString((int) (Math.random() * 10));
+        IExampleB b = IActor.getReference(IExampleB.class, id);
+        b.someWork().join();
+        return Task.done();
+    }
+
+    public Task<Integer> someWork()
+    {
+        return Task.fromValue(42);
+    }
+
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/ExampleB.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/ExampleB.java
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.demo;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.actors.runtime.Registration;
+import com.ea.orbit.concurrent.Task;
+
+import java.util.concurrent.TimeUnit;
+
+public class ExampleB extends OrbitActor implements IExampleB
+{
+
+    Registration timer;
+
+    @Override
+    public Task activateAsync()
+    {
+        int interval = 100 + ((int) Math.random() * 3000);
+        timer = registerTimer(() -> callRandomA(), interval, interval, TimeUnit.MILLISECONDS);
+        return super.activateAsync();
+    }
+
+    @Override
+    public Task<Void> callRandomA()
+    {
+        if (Math.random() > 0.5d) return Task.done(); //some variance to the calls
+        String id = Integer.toString((int) (Math.random() * 10));
+        IExampleA a = IActor.getReference(IExampleA.class, id);
+        a.someWork().join();
+        return Task.done();
+    }
+
+    public Task<Integer> someWork()
+    {
+        return Task.fromValue(24);
+    }
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/IExampleA.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/IExampleA.java
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.demo;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.annotation.OneWay;
+import com.ea.orbit.concurrent.Task;
+
+public interface IExampleA extends IActor
+{
+    @OneWay
+    Task<Void> callRandomB();
+
+    Task<Integer> someWork();
+
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/IExampleB.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/IExampleB.java
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.demo;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.annotation.OneWay;
+import com.ea.orbit.concurrent.Task;
+
+public interface IExampleB extends IActor
+{
+    @OneWay
+    Task<Void> callRandomA();
+
+    Task<Integer> someWork();
+
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/TraceDemoMain.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/demo/TraceDemoMain.java
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.demo;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.OrbitStage;
+import com.ea.orbit.samples.trace.messaging.TraceMulticastMessaging;
+import com.ea.orbit.samples.trace.receiver.TraceReceiver;
+import com.ea.orbit.samples.trace.receiver.filter.GlobTraceFilter;
+import com.ea.orbit.samples.trace.receiver.view.DiagramTraceView;
+import com.ea.orbit.samples.trace.receiver.view.RealtimeGraphView;
+import com.ea.orbit.samples.trace.receiver.view.TableTraceView;
+import com.ea.orbit.samples.trace.sender.TraceSender;
+
+public class TraceDemoMain
+{
+
+    public static void main(String[] args) throws Exception
+    {
+        System.setProperty("java.net.preferIPv4Stack", "true");
+        OrbitStage stage = new OrbitStage();
+        stage.setClusterName("traceCluster" + Math.random());
+
+        //MESSAGING
+        TraceMulticastMessaging messaging = new TraceMulticastMessaging();
+        messaging.setGroupAddress(randomGroupAddress());
+        messaging.setPort(8888);
+        messaging.start();
+
+        //SENDER
+        TraceSender sender = new TraceSender();
+        sender.setMessaging(messaging);
+        stage.addProvider(sender);
+
+        //RECEIVER
+        TraceReceiver receiver = new TraceReceiver();
+        receiver.setMessaging(messaging);
+        receiver.setFilter(new GlobTraceFilter(800, 0, 400, 80));
+        receiver.addView(new RealtimeGraphView(800, 80, 1024, 300));
+        receiver.addView(new TableTraceView(800, 410, 1024, 200));
+        receiver.addView(new DiagramTraceView("./samples/trace/graph.css"));
+        //receiver.addView(new TextTraceView());
+        receiver.start();
+
+        //start some cluster activity
+        stage.start().join();
+        IExampleA first = IActor.getReference(IExampleA.class, "0");
+        first.someWork().join();
+
+    }
+
+    public static String randomGroupAddress()
+    {
+        //multicast range is from 224.0.0.0 to 239.255.255.255
+        return "" + (224 + (int) (Math.random() * 15)) + "." + (int) (Math.random() * 255) + "." + (int) (Math.random() * 255) + "." + (int) (Math.random() * 255);
+    }
+
+}
+

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/messaging/ITraceMessaging.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/messaging/ITraceMessaging.java
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.messaging;
+
+public interface ITraceMessaging
+{
+    void start();
+
+    void send(TraceInfo info);
+
+    TraceInfo receive();
+
+    void stop();
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/messaging/TraceInfo.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/messaging/TraceInfo.java
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.messaging;
+
+import java.io.Serializable;
+
+public class TraceInfo implements Serializable
+{
+    public String sourceInterface;
+    public String targetInterface;
+    public String sourceId;
+    public String targetId;
+    public Object[] params;
+    public int methodId;
+    public Object result;
+    public long start;
+    public long end;
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/messaging/TraceMulticastMessaging.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/messaging/TraceMulticastMessaging.java
@@ -1,0 +1,148 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class TraceMulticastMessaging implements ITraceMessaging
+{
+    private String groupAddress = "239.0.0.3";
+    private int port = 8888;
+    private Thread receiverThread;
+    private Thread senderThread;
+    private ObjectMapper mapper = new ObjectMapper();
+    private ConcurrentLinkedQueue<TraceInfo> receiveQueue = new ConcurrentLinkedQueue<>();
+    private LinkedBlockingQueue<TraceInfo> sendQueue = new LinkedBlockingQueue<>();
+    private byte[] readBuffer = new byte[65535];
+
+    public TraceMulticastMessaging()
+    {
+    }
+
+    public void start()
+    {
+
+        receiverThread = new Thread(() ->
+        {
+            try
+            {
+                InetAddress address = InetAddress.getByName(groupAddress);
+                MulticastSocket clientSocket = new MulticastSocket(port);
+                clientSocket.joinGroup(address);
+                while (true)
+                {
+                    DatagramPacket msgPacket = new DatagramPacket(readBuffer, readBuffer.length);
+                    clientSocket.receive(msgPacket);
+                    TraceInfo info = mapper.readValue(readBuffer, 0, readBuffer.length, TraceInfo.class);
+                    receiveQueue.offer(info);
+                }
+            }
+            catch (Exception ex)
+            {
+                ex.printStackTrace();
+            }
+        });
+        receiverThread.setDaemon(true);
+        receiverThread.start();
+        senderThread = new Thread(() ->
+        {
+            try
+            {
+                InetAddress group = InetAddress.getByName(groupAddress);
+                while (senderThread.isAlive())
+                {
+                    TraceInfo info = sendQueue.take();
+                    try
+                    {
+                        String out = mapper.writeValueAsString(info);
+                        byte[] buf = out.getBytes();
+                        DatagramPacket packet = new DatagramPacket(buf, buf.length, group, port);
+                        DatagramSocket socket = new DatagramSocket();
+                        socket.send(packet);
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ex.printStackTrace();
+            }
+        });
+        senderThread.setDaemon(true);
+        senderThread.start();
+    }
+
+    public void stop()
+    {
+        receiverThread.interrupt();
+        senderThread.interrupt();
+    }
+
+    @Override
+    public void send(final TraceInfo info)
+    {
+        sendQueue.offer(info);
+    }
+
+    @Override
+    public TraceInfo receive()
+    {
+        return receiveQueue.poll();
+    }
+
+    public void setPort(final int port)
+    {
+        this.port = port;
+    }
+
+    public void setGroupAddress(final String groupAddress)
+    {
+        this.groupAddress = groupAddress;
+    }
+
+    public String getGroupAddress()
+    {
+        return groupAddress;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/TraceReceiver.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/TraceReceiver.java
@@ -1,0 +1,120 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver;
+
+import com.ea.orbit.samples.trace.messaging.ITraceMessaging;
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+import com.ea.orbit.samples.trace.messaging.TraceMulticastMessaging;
+import com.ea.orbit.samples.trace.receiver.filter.ITraceFilter;
+import com.ea.orbit.samples.trace.receiver.view.ITraceView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TraceReceiver
+{
+
+    public static final int TRACE_STEP_MILLIS = 100;
+
+    private Thread thread;
+    private ITraceMessaging messaging = new TraceMulticastMessaging(); //default implementation
+
+    private ITraceFilter filter = new ITraceFilter()
+    {
+    };
+
+    private List<ITraceView> views = new ArrayList<>();
+
+    public void addView(ITraceView view)
+    {
+        views.add(view);
+    }
+
+    public void start()
+    {
+        thread = new Thread(() -> {
+            while (true)
+            {
+                TraceInfo info = messaging.receive();
+                while (info != null)
+                {
+                    for (ITraceView l : views)
+                    {
+                        try
+                        {
+                            if (filter.allows(info))
+                            {
+                                l.trace(info);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            e.printStackTrace();
+                        }
+                    }
+                    info = messaging.receive();
+                }
+                try
+                {
+                    Thread.sleep(TraceReceiver.TRACE_STEP_MILLIS);
+                }
+                catch (InterruptedException e)
+                {
+                }
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    public void stop()
+    {
+        thread.interrupt();
+    }
+
+    public ITraceMessaging getMessaging()
+    {
+        return messaging;
+    }
+
+    public void setMessaging(final ITraceMessaging messaging)
+    {
+        this.messaging = messaging;
+    }
+
+    public ITraceFilter getFilter()
+    {
+        return filter;
+    }
+
+    public void setFilter(final ITraceFilter filter)
+    {
+        this.filter = filter;
+    }
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/filter/GlobTraceFilter.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/filter/GlobTraceFilter.java
@@ -1,0 +1,99 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.filter;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import java.awt.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GlobTraceFilter implements ITraceFilter
+{
+    private JTextField field = new JTextField();
+    private Matcher matcher;
+    private Pattern pattern;
+
+    public GlobTraceFilter(int x, int y, int width, int height)
+    {
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("Glob Filter (Target)");
+            frame.setPreferredSize(new Dimension(width, height));
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            field.getDocument().addDocumentListener(new DocumentListener()
+            {
+                @Override
+                public void insertUpdate(final DocumentEvent e)
+                {
+                    changedUpdate(e);
+                }
+
+                @Override
+                public void removeUpdate(final DocumentEvent e)
+                {
+                    changedUpdate(e);
+                }
+
+                public void changedUpdate(DocumentEvent e)
+                {
+                    String current = field.getText();
+                    if (current == null)
+                    {
+                        pattern = null;
+                        return;
+                    }
+                    String regex = GlobUtil.convertGlobToRegEx(current);
+                    pattern = Pattern.compile(regex);
+                    matcher = pattern.matcher("");
+                }
+
+            });
+
+            frame.add(field);
+            frame.pack();
+            frame.setLocation(x, y);
+            frame.setVisible(true);
+        });
+    }
+
+    @Override
+    public boolean allows(final TraceInfo info)
+    {
+        if (pattern != null)
+        {
+            return matcher.reset(info.targetInterface).find();
+        }
+
+        return true;
+    }
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/filter/GlobUtil.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/filter/GlobUtil.java
@@ -1,0 +1,128 @@
+package com.ea.orbit.samples.trace.receiver.filter;
+
+//source: http://stackoverflow.com/questions/1247772/is-there-an-equivalent-of-java-util-regex-for-glob-type-patterns
+//license: http://creativecommons.org/licenses/by-sa/3.0/
+//author: http://stackoverflow.com/users/3333/paul-tomblin
+
+public class GlobUtil
+{
+
+    public static String convertGlobToRegEx(String line)
+    {
+        line = line.trim();
+        int strLen = line.length();
+        StringBuilder sb = new StringBuilder(strLen);
+        // Remove beginning and ending * globs because they're useless
+        if (line.startsWith("*"))
+        {
+            line = line.substring(1);
+            strLen--;
+        }
+        if (line.endsWith("*"))
+        {
+            line = line.substring(0, strLen - 1);
+            strLen--;
+        }
+        boolean escaping = false;
+        int inCurlies = 0;
+        for (char currentChar : line.toCharArray())
+        {
+            switch (currentChar)
+            {
+                case '*':
+                    if (escaping)
+                    {
+                        sb.append("\\*");
+                    }
+                    else
+                    {
+                        sb.append(".*");
+                    }
+                    escaping = false;
+                    break;
+                case '?':
+                    if (escaping)
+                    {
+                        sb.append("\\?");
+                    }
+                    else
+                    {
+                        sb.append('.');
+                    }
+                    escaping = false;
+                    break;
+                case '.':
+                case '(':
+                case ')':
+                case '+':
+                case '|':
+                case '^':
+                case '$':
+                case '@':
+                case '%':
+                    sb.append('\\');
+                    sb.append(currentChar);
+                    escaping = false;
+                    break;
+                case '\\':
+                    if (escaping)
+                    {
+                        sb.append("\\\\");
+                        escaping = false;
+                    }
+                    else
+                    {
+                        escaping = true;
+                    }
+                    break;
+                case '{':
+                    if (escaping)
+                    {
+                        sb.append("\\{");
+                    }
+                    else
+                    {
+                        sb.append('(');
+                        inCurlies++;
+                    }
+                    escaping = false;
+                    break;
+                case '}':
+                    if (inCurlies > 0 && !escaping)
+                    {
+                        sb.append(')');
+                        inCurlies--;
+                    }
+                    else if (escaping)
+                    {
+                        sb.append("\\}");
+                    }
+                    else
+                    {
+                        sb.append("}");
+                    }
+                    escaping = false;
+                    break;
+                case ',':
+                    if (inCurlies > 0 && !escaping)
+                    {
+                        sb.append('|');
+                    }
+                    else if (escaping)
+                    {
+                        sb.append("\\,");
+                    }
+                    else
+                    {
+                        sb.append(",");
+                    }
+                    break;
+                default:
+                    escaping = false;
+                    sb.append(currentChar);
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/filter/ITraceFilter.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/filter/ITraceFilter.java
@@ -1,0 +1,41 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.filter;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+
+public interface ITraceFilter
+{
+    default boolean allows(TraceInfo info)
+    {
+        return true;
+    }
+
+    ;
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/DiagramTraceView.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/DiagramTraceView.java
@@ -1,0 +1,100 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.view;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+
+import org.graphstream.graph.Edge;
+import org.graphstream.graph.Graph;
+import org.graphstream.graph.Node;
+import org.graphstream.graph.implementations.MultiGraph;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class DiagramTraceView implements ITraceView
+{
+    private Graph graph;
+
+    public DiagramTraceView(String cssFile)
+    {
+        System.setProperty("gs.ui.renderer", "org.graphstream.ui.j2dviewer.J2DGraphRenderer");
+        graph = new MultiGraph("Cluster", true, true);
+        graph.addAttribute("ui.stylesheet", "url('file:" + cssFile + "')");
+        graph.addAttribute("ui.quality");
+        graph.addAttribute("ui.antialias");
+        graph.display();
+    }
+
+    ConcurrentLinkedQueue<String> edgeKeys = new ConcurrentLinkedQueue<>();
+
+    public void trace(final TraceInfo info)
+    {
+        try
+        {
+            String sourceName = info.sourceInterface.substring(info.sourceInterface.lastIndexOf('.') + 1) + info.sourceId;
+            String targetName = info.targetInterface.substring(info.targetInterface.lastIndexOf('.') + 1) + info.targetId;
+            getNodeOrCreate(sourceName);
+            getNodeOrCreate(targetName);
+
+            String edgekey = sourceName + "_" + targetName;
+            Edge edge;
+            if (!edgeKeys.contains(edgekey))
+            {
+                edge = graph.addEdge(edgekey, sourceName, targetName, true);
+                edgeKeys.offer(edgekey);
+            }
+            else
+            {
+                edge = graph.getEdge(edgekey);
+            }
+
+            if (edge != null)
+            {
+                graph.getEdge(edgekey).setAttribute("ui.style", "fill-color:rgb(" + ((int) (Math.random() * 255)) + "," + ((int) (Math.random() * 255)) + "," + ((int) (Math.random() * 255)) + ");");
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+    }
+
+    private Node getNodeOrCreate(String name)
+    {
+        Node node = graph.getNode(name);
+        if (node == null)
+        {
+            node = graph.addNode(name);
+            node.setAttribute("ui.label", name);
+        }
+        return node;
+    }
+
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/ITraceView.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/ITraceView.java
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.view;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+
+public interface ITraceView
+{
+    void trace(TraceInfo info);
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/RealtimeGraphView.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/RealtimeGraphView.java
@@ -1,0 +1,99 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.view;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+import com.ea.orbit.samples.trace.receiver.TraceReceiver;
+
+import com.xeiam.xchart.Chart;
+import com.xeiam.xchart.XChartPanel;
+
+import javax.swing.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RealtimeGraphView implements ITraceView
+{
+
+    private List<Long> yData = new ArrayList();
+    private AtomicLong requestsPerSecond = new AtomicLong(0);
+
+    public RealtimeGraphView(int x, int y, int width, int height)
+    {
+        Chart chart = new Chart(width, height);
+        chart.setChartTitle("Actors Requests per Second");
+        chart.setXAxisTitle("Time");
+        chart.setYAxisTitle("Requests");
+        chart.getStyleManager().setYAxisMin(0);
+        yData.add(0L);
+        chart.addSeries("requests", null, yData);
+        final XChartPanel chartPanel = new XChartPanel(chart);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("Realtime");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.add(chartPanel);
+            frame.pack();
+            frame.setVisible(true);
+            frame.setLocation(x, y);
+        });
+
+        TimerTask chartUpdaterTask = new TimerTask()
+        {
+            @Override
+            public void run()
+            {
+                long currentValue = (long) (requestsPerSecond.incrementAndGet() * (1000.0 / (TraceReceiver.TRACE_STEP_MILLIS * 5.0)));
+                yData.add(currentValue);
+                requestsPerSecond.set(0);
+                while (yData.size() > 100)
+                {
+                    yData.remove(0);
+                }
+                long max = yData.stream().mapToLong(l -> l).max().getAsLong();
+                chart.getStyleManager().setYAxisMax(max + 10);
+                javax.swing.SwingUtilities.invokeLater(() -> {
+                    chartPanel.updateSeries("requests", new ArrayList<>(yData));
+                });
+            }
+        };
+
+        Timer timer = new Timer();
+        timer.scheduleAtFixedRate(chartUpdaterTask, 0, TraceReceiver.TRACE_STEP_MILLIS * 5);
+    }
+
+    @Override
+    public void trace(final TraceInfo info)
+    {
+        requestsPerSecond.incrementAndGet();
+    }
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/TableTraceView.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/TableTraceView.java
@@ -1,0 +1,142 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.view;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+
+import java.awt.*;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TableTraceView implements ITraceView
+{
+    public static String[] colNames = new String[]{ "TIMESTAMP", "SOURCE", "ID", "TARGET", "ID", "METHOD", "ELAPSED" };
+
+    List<TraceInfo> current = new LinkedList<>();
+    TraceInfoTableModel model;
+
+    public TableTraceView(int x, int y, int width, int height)
+    {
+        model = new TraceInfoTableModel();
+
+        JTable table = new JTable(model);
+        table.getColumn(colNames[0]).setMinWidth(170);
+        table.getColumn(colNames[1]).setMinWidth(260);
+        table.getColumn(colNames[3]).setMinWidth(260);
+
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("Table");
+            frame.setPreferredSize(new Dimension(width, height));
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.add(new JScrollPane(table));
+            frame.pack();
+            frame.setVisible(true);
+            frame.setLocation(x, y);
+        });
+    }
+
+    private class TraceInfoTableModel extends AbstractTableModel
+    {
+        @Override
+        public String getColumnName(int col)
+        {
+            return colNames[col];
+        }
+
+        @Override
+        public int getRowCount()
+        {
+            return current.size();
+        }
+
+        @Override
+        public int getColumnCount()
+        {
+            return colNames.length;
+        }
+
+        @Override
+        public Object getValueAt(final int rowIndex, final int columnIndex)
+        {
+            TraceInfo row = current.get(rowIndex);
+            if (0 == columnIndex)
+            {
+                return new Date(row.start);
+            }
+            else if (1 == columnIndex)
+            {
+                return row.sourceInterface;
+            }
+            else if (2 == columnIndex)
+            {
+                return row.sourceId;
+            }
+            else if (3 == columnIndex)
+            {
+                return row.targetInterface;
+            }
+            else if (4 == columnIndex)
+            {
+                return row.targetId;
+            }
+            else if (5 == columnIndex)
+            {
+                return row.methodId;
+            }
+            else if (6 == columnIndex)
+            {
+                return row.end - row.start;
+            }
+            return null;
+        }
+    }
+
+    @Override
+    public void trace(final TraceInfo info)
+    {
+        current.add(info);
+        if (current.size() > 50)
+        {
+            current.remove(0);
+        }
+        if ((System.currentTimeMillis() - lastUpdate) > 500)
+        {
+            lastUpdate = System.currentTimeMillis();
+            model.fireTableDataChanged();
+        }
+    }
+
+    long lastUpdate = 0;
+
+
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/TextTraceView.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/receiver/view/TextTraceView.java
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.receiver.view;
+
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+
+public class TextTraceView implements ITraceView
+{
+
+    public void trace(TraceInfo info)
+    {
+        System.out.println("" + info.start + " | source:" + info.sourceInterface + "[" + info.sourceId + "] | target:" + info.targetInterface + "[" + info.targetId + "] | methodId:" + info.methodId + " | result:" + String.valueOf(info.result) + " | elapsed:" + (info.end - info.start));
+    }
+}

--- a/samples/trace/src/main/java/com/ea/orbit/samples/trace/sender/TraceSender.java
+++ b/samples/trace/src/main/java/com/ea/orbit/samples/trace/sender/TraceSender.java
@@ -1,0 +1,145 @@
+/*
+Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+    its contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package com.ea.orbit.samples.trace.sender;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.providers.IInvokeListenerProvider;
+import com.ea.orbit.actors.runtime.Execution;
+import com.ea.orbit.samples.trace.messaging.ITraceMessaging;
+import com.ea.orbit.samples.trace.messaging.TraceInfo;
+import com.ea.orbit.samples.trace.messaging.TraceMulticastMessaging;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+public class TraceSender implements IInvokeListenerProvider
+{
+
+    private ITraceMessaging messaging = new TraceMulticastMessaging(); //default implementation
+
+    public TraceSender()
+    {
+        Execution.traceEnabled = true;
+    }
+
+    Cache<Long, TraceInfo> traceMap = CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES)
+            .build();
+
+    public void preInvoke(long traceId, String sourceInterface, String sourceId, String targetInterface, String targetId, int methodId, Object[] params)
+    {
+        if (!Execution.traceEnabled)
+        {
+            return;
+        }
+        try
+        {
+            if (isIgnorable(sourceInterface) || isIgnorable(targetInterface))
+            {
+                return;
+            }
+            TraceInfo info = new TraceInfo();
+            info.sourceInterface = sourceInterface;
+            info.targetInterface = targetInterface;
+            info.sourceId = sourceId;
+            info.targetId = targetId;
+            info.methodId = methodId;
+            info.params = params;
+            info.start = System.currentTimeMillis();
+            traceMap.put(traceId, info);
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+        return;
+    }
+
+    public void postInvoke(long traceId, Object result)
+    {
+        if (!Execution.traceEnabled)
+        {
+            return;
+        }
+        try
+        {
+            TraceInfo info = traceMap.getIfPresent(traceId);
+            if (info != null)
+            {
+                traceMap.invalidate(traceId);
+                if (info != null)
+                {
+                    info.result = result;
+                    info.end = System.currentTimeMillis();
+                    messaging.send(info);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isIgnorable(String value)
+    {
+        if (value == null)
+        {
+            return true;
+        }
+
+        try
+        {
+            if (!IActor.class.isAssignableFrom(Class.forName(value)))
+            {
+                return true;
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        //TODO REMOTE FILTER
+        //Remote filter is a good option for IO economy, but different receivers may have different filter needs. The sender filter should merge them somehow.
+        return false;
+    }
+
+    public ITraceMessaging getMessaging()
+    {
+        return messaging;
+    }
+
+    public void setMessaging(final ITraceMessaging messaging)
+    {
+        this.messaging = messaging;
+    }
+
+}

--- a/samples/trace/src/main/resources/logback.xml
+++ b/samples/trace/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="com.ea.orbit.samples.hello" level="INFO"/>
+
+</configuration>


### PR DESCRIPTION
Cluster Trace
======

![tracedemo](https://cloud.githubusercontent.com/assets/874378/7213889/e9554c02-e565-11e4-9f00-e423ffc6ff57.png)

This is a proof of concept for a Trace API for the orbit cluster
-----

I had the idea to develop a trace api to make the cluster flows easier to debug.
There were small changes to the core, most of the code here presented is of a demo application (*TraceDemoMain*) with views that use the trace api.
Some key decisions at the demo:
* Use a separated messaging system (simple multicast) to avoid using the cluster infra and affect the metrics.
* Possibility to disable tracing at the production
* Direct Listeners (not tasks) and queues for buffering.
* Support for receiver filtering and views.

There are a lot of possible improvements, but this should be discussed before more effort. Any doubts just drop a line. :)

[]s, Ricardo Mello (gandhi)

PS: I´ll be online rarely the next 5 days because of brazilian holydays.



