### PR TITLE
Fix compiler warnings.

### DIFF
--- a/async/src/main/java/com/ea/orbit/async/processor/Processor.java
+++ b/async/src/main/java/com/ea/orbit/async/processor/Processor.java
@@ -33,6 +33,8 @@ import com.ea.orbit.async.Async;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -45,6 +47,7 @@ import java.util.Set;
  * Annotation processor to detect misuses of {@literal@}Async
  */
 @SupportedAnnotationTypes({ "com.orbit.async.Async" })
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class Processor extends AbstractProcessor
 {
     @Override


### PR DESCRIPTION
Should get rid of these warnings..

Warning:java: No SupportedSourceVersion annotation found on com.ea.orbit.async.processor.Processor, returning RELEASE_6.
Warning:java: Supported source version 'RELEASE_6' from annotation processor 'com.ea.orbit.async.processor.Processor' less than -source '1.8'