### PR TITLE
Added support for mutiple storages by using StorageProvider annotation

### DIFF
--- a/actors/core/src/main/java/com/ea/orbit/actors/annotation/StorageProvider.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/annotation/StorageProvider.java
@@ -1,0 +1,44 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package com.ea.orbit.actors.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface StorageProvider
+{
+
+    String name() default "default";
+
+}

--- a/actors/core/src/main/java/com/ea/orbit/actors/providers/AbstractStorageProvider.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/providers/AbstractStorageProvider.java
@@ -1,0 +1,44 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.providers;
+
+public abstract class AbstractStorageProvider implements IStorageProvider
+{
+
+    protected String name;
+
+    public void setName(String name){
+        this.name = name;
+    }
+
+    public String name(){
+        return name;
+    }
+
+}

--- a/actors/core/src/main/java/com/ea/orbit/actors/providers/IStorageProvider.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/providers/IStorageProvider.java
@@ -36,6 +36,13 @@ import com.ea.orbit.concurrent.Task;
  */
 public interface IStorageProvider extends IOrbitProvider
 {
+
+    /**
+     * Returns this storage provider name.
+     * @return storage provider name
+     */
+    default String name() { return "default"; }
+
     /**
      * Asynchronously clears an actors state.
      * @param reference an reference to the actor (contains the interface name and actor key)

--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
@@ -28,7 +28,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.ea.orbit.actors.providers.jpa;
 
-import com.ea.orbit.actors.providers.IStorageProvider;
+import com.ea.orbit.actors.providers.AbstractStorageProvider;
 import com.ea.orbit.actors.runtime.ActorReference;
 import com.ea.orbit.concurrent.Task;
 import com.ea.orbit.exception.UncheckedException;
@@ -42,7 +42,7 @@ import javax.persistence.NoResultException;
 import javax.persistence.Persistence;
 import javax.persistence.Query;
 
-public class JpaStorageProvider implements IStorageProvider
+public class JpaStorageProvider extends AbstractStorageProvider
 {
 
     private String persistenceUnitName = "jp-storage-production";

--- a/actors/providers/memcached/src/main/java/com/ea/orbit/actors/providers/memcached/MemCachedStorageProvider.java
+++ b/actors/providers/memcached/src/main/java/com/ea/orbit/actors/providers/memcached/MemCachedStorageProvider.java
@@ -28,6 +28,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.ea.orbit.actors.providers.memcached;
 
+import com.ea.orbit.actors.providers.AbstractStorageProvider;
 import com.ea.orbit.actors.providers.IStorageProvider;
 import com.ea.orbit.actors.providers.json.ActorReferenceModule;
 import com.ea.orbit.actors.runtime.ActorReference;
@@ -49,7 +50,7 @@ import java.io.IOException;
  *
  * @author Johno Crawford (johno@sulake.com)
  */
-public class MemCachedStorageProvider implements IStorageProvider
+public class MemCachedStorageProvider extends AbstractStorageProvider
 {
 
     private static final Logger logger = LoggerFactory.getLogger(MemCachedStorageProvider.class);

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/FakeStorageProvider.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/FakeStorageProvider.java
@@ -44,11 +44,23 @@ import java.util.concurrent.ConcurrentMap;
 
 public class FakeStorageProvider implements IStorageProvider
 {
-    private ConcurrentMap<Object,Object> database;
+    private ConcurrentMap<Object, Object> database;
     private ObjectMapper mapper = new ObjectMapper();
+    private String name;
 
-    public FakeStorageProvider(final ConcurrentMap<Object,Object> database)
+    public String name()
     {
+        return name;
+    }
+
+    public FakeStorageProvider(final ConcurrentMap<Object, Object> database)
+    {
+        this("fake", database);
+    }
+
+    public FakeStorageProvider(String name, final ConcurrentMap<Object, Object> database)
+    {
+        this.name = name;
         this.database = database;
         mapper.registerModule(new ActorReferenceModule(new ReferenceFactory()));
 

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/MultipleStorageTest.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/MultipleStorageTest.java
@@ -1,0 +1,109 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.OrbitStage;
+import com.ea.orbit.actors.test.actors.IStorage1Actor;
+import com.ea.orbit.actors.test.actors.IStorage2Actor;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("unused")
+public class MultipleStorageTest extends ActorBaseTest
+{
+    protected ConcurrentHashMap<Object, Object> fakeDatabase1 = new ConcurrentHashMap<>();
+    protected ConcurrentHashMap<Object, Object> fakeDatabase2 = new ConcurrentHashMap<>();
+
+    @Test
+    public void checkWritesTest() throws ExecutionException, InterruptedException
+    {
+        OrbitStage stage1 = createStage();
+        assertEquals(0, fakeDatabase1.values().size());
+        assertEquals(0, fakeDatabase2.values().size());
+
+        IStorage1Actor storage1A = IActor.getReference(IStorage1Actor.class, "301");
+        IStorage1Actor storage1B = IActor.getReference(IStorage1Actor.class, "302");
+        IStorage1Actor storage1C = IActor.getReference(IStorage1Actor.class, "303");
+        IStorage1Actor storage1D = IActor.getReference(IStorage1Actor.class, "304");
+        IStorage2Actor storage2A = IActor.getReference(IStorage2Actor.class, "400");
+        IStorage2Actor storage2B = IActor.getReference(IStorage2Actor.class, "401");
+
+        storage1A.put("I").join();
+        storage1B.put("am").join();
+        storage1C.put("testing").join();
+        storage1D.put("something").join();
+        assertEquals(4, fakeDatabase1.values().size());
+        assertEquals(0, fakeDatabase2.values().size());
+        storage2A.put("really").join();
+        storage2B.put("cool").join();
+
+        assertEquals(4, fakeDatabase1.values().size());
+        assertEquals(2, fakeDatabase2.values().size());
+
+        OrbitStage stage2 = createStage();
+
+        IStorage1Actor storage1AA = IActor.getReference(IStorage1Actor.class, "301");
+        IStorage1Actor storage1BB = IActor.getReference(IStorage1Actor.class, "302");
+        IStorage1Actor storage1CC = IActor.getReference(IStorage1Actor.class, "303");
+        IStorage1Actor storage1DD = IActor.getReference(IStorage1Actor.class, "304");
+        IStorage2Actor storage2AA = IActor.getReference(IStorage2Actor.class, "400");
+        IStorage2Actor storage2BB = IActor.getReference(IStorage2Actor.class, "401");
+
+        assertEquals("I", storage1AA.get().join());
+        assertEquals("am", storage1BB.get().join());
+        assertEquals("testing", storage1CC.get().join());
+        assertEquals("something", storage1DD.get().join());
+        assertEquals("really", storage2AA.get().join());
+        assertEquals("cool", storage2BB.get().join());
+
+    }
+
+    @Override
+    public OrbitStage createStage() throws ExecutionException, InterruptedException
+    {
+        OrbitStage stage = new OrbitStage();
+        stage.setMode(OrbitStage.StageMode.HOST);
+        stage.setExecutionPool(commonPool);
+        stage.setMessagingPool(commonPool);
+        stage.addProvider(new FakeStorageProvider("fake1", fakeDatabase1));
+        stage.addProvider(new FakeStorageProvider("fake2", fakeDatabase2));
+        stage.setClock(clock);
+        stage.setClusterName(clusterName);
+        stage.setClusterPeer(new FakeClusterPeer());
+        stage.start().join();
+        stage.bind();
+        return stage;
+    }
+}

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/IStorage1Actor.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/IStorage1Actor.java
@@ -1,0 +1,41 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test.actors;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.concurrent.Task;
+
+public interface IStorage1Actor extends IActor
+{
+
+    Task<Void> put(String value);
+
+    Task<String> get();
+
+}

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/IStorage2Actor.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/IStorage2Actor.java
@@ -1,0 +1,41 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test.actors;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.concurrent.Task;
+
+public interface IStorage2Actor extends IActor
+{
+
+    Task<Void> put(String value);
+
+    Task<String> get();
+
+}

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/Storage1Actor.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/Storage1Actor.java
@@ -1,0 +1,55 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test.actors;
+
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.concurrent.Task;
+
+//no storage provider annotation, will be the default storage (first found)
+public class Storage1Actor extends OrbitActor<Storage1Actor.State> implements IStorage1Actor
+{
+
+    public static class State
+    {
+        public String value;
+    }
+
+    @Override
+    public Task<Void> put(final String value)
+    {
+        state().value = value;
+        return writeState();
+    }
+
+    @Override
+    public Task<String> get()
+    {
+        return Task.fromValue(state().value);
+    }
+}

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/Storage2Actor.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/Storage2Actor.java
@@ -1,0 +1,56 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test.actors;
+
+import com.ea.orbit.actors.annotation.StorageProvider;
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.concurrent.Task;
+
+@StorageProvider(name = "fake2")
+public class Storage2Actor extends OrbitActor<Storage2Actor.State> implements IStorage2Actor
+{
+
+    public static class State
+    {
+        public String value;
+    }
+
+    @Override
+    public Task<Void> put(final String value)
+    {
+        state().value = value;
+        return writeState();
+    }
+
+    @Override
+    public Task<String> get()
+    {
+        return Task.fromValue(state().value);
+    }
+}


### PR DESCRIPTION
This is a minimum support for multiple storages. The developer just have to set a storage name and use the same name using the annotation.
-------

```
RedisStorageProvider storageProvider = new RedisStorageProvider();
storageProvider.setName("gamestate")
storageProvider.setTimeout(60000);
storageProvider.setDatabaseName(databaseName);
stage.addProvider(storageProvider );

...

@StorageProvider(name = "gamestate")
public class SomeActor extends OrbitActor<SomeActor.State> implements ISomeActor
{
}
```

Note: The default behaviour is mantained, without any annotation the first provider is used.
-------