### PR TITLE
Added embedded apacheds LDAP server for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 before_script:
   - psql -c 'create database orbit;' -U postgres
 
-script: "mvn test -P withMongoTests,withPostgresTests,withRedisTests,withMemcachedTests,withScala"
+script: "mvn test -P withMongoTests,withPostgresTests,withRedisTests,withMemcachedTests,withScala,withLDAPTests"
 
 notifications:
   webhooks:

--- a/actors/providers/ldap/pom.xml
+++ b/actors/providers/ldap/pom.xml
@@ -65,11 +65,13 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>orbit-actors-json</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-all</artifactId>
-            <version>1.0.0-M30</version>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-all</artifactId>
+            <version>2.0.0-M20</version>
         </dependency>
+
         <dependency>
             <groupId>com.ea.orbit</groupId>
             <artifactId>orbit-actors-tests</artifactId>


### PR DESCRIPTION
I initially tried to make a travis shell script to install openldap, but it was a total mess to configure. I eventually discovered that apacheds already has an integration with unit tests and I use it.
I´m not totally in favor of using the server that shares code with the client api, I think that by using a different server, it would be more easy to find compatibility bugs.
I also enabled the test at the travis file, I dont know if it will be enabled by default.