### PR TITLE
Jpa Storage fix to support objects not marked as entities

### DIFF
--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaGenericData.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaGenericData.java
@@ -1,0 +1,39 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.providers.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "orbit_generic_data")
+public class JpaGenericData extends JpaState
+{
+    public String jsonData;
+}

--- a/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
+++ b/actors/providers/jpa/src/main/java/com/ea/orbit/actors/providers/jpa/JpaStorageProvider.java
@@ -36,6 +36,7 @@ import com.ea.orbit.exception.UncheckedException;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.NoResultException;
@@ -63,7 +64,7 @@ public class JpaStorageProvider extends AbstractStorageProvider
         {
             String stateId = getIdentity(reference);
             EntityManager em = emf.createEntityManager();
-            Query query = em.createQuery("delete from " + state.getClass().getSimpleName() + " s where s.stateId=:stateId");
+            Query query = em.createQuery("delete from " + state.getClass().getName() + " s where s.stateId=:stateId");
             query.setParameter("stateId", stateId);
             em.getTransaction().begin();
             query.executeUpdate();
@@ -78,18 +79,31 @@ public class JpaStorageProvider extends AbstractStorageProvider
     }
 
     @Override
-    public synchronized Task<Boolean> readState(final ActorReference<?> reference, final Object state)
+    public synchronized Task<Boolean> readState(final ActorReference<?> reference, Object state)
     {
         try
         {
+            boolean isJpaEntity = state.getClass().isAnnotationPresent(Entity.class);
             String stateId = getIdentity(reference);
             EntityManager em = emf.createEntityManager();
-            Query query = em.createQuery("select s from " + state.getClass().getSimpleName() + " s where s.stateId=:stateId");
+
+            String className = state.getClass().getName();
+
+            if (!isJpaEntity)
+            {
+                className = JpaGenericData.class.getName();
+            }
+
+            Query query = em.createQuery("select s from " + className + " s where s.stateId=:stateId");
             query.setParameter("stateId", stateId);
             Object newState;
             try
             {
                 newState = query.getSingleResult();
+                if (!isJpaEntity)
+                {
+                    newState = mapper.readValue((((JpaGenericData) newState).jsonData), state.getClass());
+                }
                 mapper.readerForUpdating(state).readValue(mapper.writeValueAsString(newState));
                 return Task.fromValue(true);
             }
@@ -109,13 +123,23 @@ public class JpaStorageProvider extends AbstractStorageProvider
     }
 
     @Override
-    public synchronized Task<Void> writeState(final ActorReference<?> reference, final Object state)
+    public synchronized Task<Void> writeState(final ActorReference<?> reference, Object state)
     {
-        String identity = getIdentity(reference);
-        JpaState jpaState = (JpaState) state;
-        jpaState.stateId = identity;
+        boolean isJpaEntity = state.getClass().isAnnotationPresent(Entity.class);
+
         try
         {
+            if (!isJpaEntity)
+            {
+                JpaGenericData tmp = new JpaGenericData();
+                tmp.jsonData = mapper.writeValueAsString(state);
+                state = tmp;
+            }
+
+            String identity = getIdentity(reference);
+            JpaState jpaState = (JpaState) state;
+            jpaState.stateId = identity;
+
             EntityManager em = emf.createEntityManager();
             em.getTransaction().begin();
             em.merge(state);

--- a/actors/providers/jpa/src/test/resources/META-INF/persistence.xml
+++ b/actors/providers/jpa/src/test/resources/META-INF/persistence.xml
@@ -5,6 +5,7 @@
 
     <persistence-unit name="jpa-storage-test" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>com.ea.orbit.actors.providers.jpa.JpaGenericData</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="javax.persistence.jdbc.password" value="123456"/>
@@ -18,6 +19,7 @@
 
     <persistence-unit name="jpa-storage-production" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <class>com.ea.orbit.actors.providers.jpa.JpaGenericData</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="javax.persistence.jdbc.password" value="123456"/>

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/IReminderTestActor.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/IReminderTestActor.java
@@ -1,0 +1,40 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test;
+
+import com.ea.orbit.actors.IActor;
+import com.ea.orbit.actors.IRemindable;
+import com.ea.orbit.concurrent.Task;
+
+public interface IReminderTestActor extends IActor, IRemindable
+{
+
+    Task<Void> startReminder();
+
+}

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/ReminderTestActor.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/ReminderTestActor.java
@@ -1,0 +1,56 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.test;
+
+import com.ea.orbit.actors.runtime.OrbitActor;
+import com.ea.orbit.actors.runtime.TickStatus;
+import com.ea.orbit.concurrent.Task;
+
+import java.util.concurrent.TimeUnit;
+
+public class ReminderTestActor extends OrbitActor implements IReminderTestActor
+{
+    public static boolean waiting;
+
+    @Override
+    public Task<Void> startReminder()
+    {
+        registerReminder("hey", 1, 1, TimeUnit.SECONDS);
+        waiting = true;
+        return Task.done();
+    }
+
+    @Override
+    public Task<?> receiveReminder(final String reminderName, final TickStatus status)
+    {
+        unregisterReminder("hey");
+        waiting = false;
+        return Task.done();
+    }
+}

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/StorageBaseTest.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/StorageBaseTest.java
@@ -37,6 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public abstract class StorageBaseTest
 {
@@ -59,20 +60,23 @@ public abstract class StorageBaseTest
         // not a load test "per se" but rather a test with more than a few calls.
         OrbitStage stage = createStage();
         assertEquals(0, count());
-        for(int t=0;t< heavyTestSize();t++){
-            String id =""+t;
+        for (int t = 0; t < heavyTestSize(); t++)
+        {
+            String id = "" + t;
             IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), id);
-            helloActor.sayHello("Meep Meep"+t).join();
+            helloActor.sayHello("Meep Meep" + t).join();
         }
         assertEquals(heavyTestSize(), count());
-        for(int t=0;t< heavyTestSize();t++){
-            String id =""+t;
+        for (int t = 0; t < heavyTestSize(); t++)
+        {
+            String id = "" + t;
             IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), id);
-            helloActor.sayHello("Meep Meep"+t).join();
-            assertEquals(readState(id).lastName(), "Meep Meep"+t);
+            helloActor.sayHello("Meep Meep" + t).join();
+            assertEquals(readState(id).lastName(), "Meep Meep" + t);
         }
-        for(int t=0;t< heavyTestSize();t++){
-            String id =""+t;
+        for (int t = 0; t < heavyTestSize(); t++)
+        {
+            String id = "" + t;
             IStorageTestActor helloActor = IActor.getReference(getActorInterfaceClass(), id);
             helloActor.clear().join();
         }
@@ -114,6 +118,29 @@ public abstract class StorageBaseTest
         assertEquals(1, count());
         helloActor.sayHello("Peem Peem").join();
         assertEquals(readState("300").lastName(), "Peem Peem");
+    }
+
+    @Test
+    public void checkReminderTest() throws Exception
+    {
+        OrbitStage stage = createStage();
+        assertEquals(0, count());
+        IReminderTestActor actor = IActor.getReference(IReminderTestActor.class, "999");
+        actor.startReminder().join();
+        int count = 0;
+        while (ReminderTestActor.waiting)
+        {
+            Thread.sleep(100);
+            count++;
+            if (count > 15)
+            {
+                fail("timeout");
+            }
+        }
+        if (count < 10)
+        {
+            fail("too early");
+        }
     }
 
     public OrbitStage createStage() throws Exception


### PR DESCRIPTION
This is a fix for a recent issue, caused because the Jpa Provider only supports entity objects.
Now when an unsupported object is used, it is converted into a json object and persisted using a generic jpa object. 
A test was also created to check the reminder persistence at the providers.