### PR TITLE
Add withIsGetterVisibility for consistency.

### DIFF
--- a/actors/extensions/jpa/src/main/java/com/ea/orbit/actors/extensions/jpa/JpaStorageExtension.java
+++ b/actors/extensions/jpa/src/main/java/com/ea/orbit/actors/extensions/jpa/JpaStorageExtension.java
@@ -162,6 +162,7 @@ public class JpaStorageExtension extends AbstractStorageExtension
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 

--- a/actors/extensions/memcached/src/main/java/com/ea/orbit/actors/extensions/memcached/MemcachedStorageExtension.java
+++ b/actors/extensions/memcached/src/main/java/com/ea/orbit/actors/extensions/memcached/MemcachedStorageExtension.java
@@ -70,6 +70,7 @@ public class MemcachedStorageExtension extends AbstractStorageExtension
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 

--- a/actors/extensions/memcached/src/test/java/com/ea/orbit/actors/extensions/memcached/MemCachedPersistenceTest.java
+++ b/actors/extensions/memcached/src/test/java/com/ea/orbit/actors/extensions/memcached/MemCachedPersistenceTest.java
@@ -69,6 +69,7 @@ public class MemCachedPersistenceTest extends StorageBaseTest
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 

--- a/actors/extensions/mongodb/src/main/java/com/ea/orbit/actors/extensions/mongodb/MongoDBStorageExtension.java
+++ b/actors/extensions/mongodb/src/main/java/com/ea/orbit/actors/extensions/mongodb/MongoDBStorageExtension.java
@@ -97,6 +97,7 @@ public class MongoDBStorageExtension implements StorageExtension
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
         MongoJackModule.configure(mapper);

--- a/actors/extensions/postgresql/src/main/java/com/ea/orbit/actors/extensions/postgresql/PostgreSQLStorageExtension.java
+++ b/actors/extensions/postgresql/src/main/java/com/ea/orbit/actors/extensions/postgresql/PostgreSQLStorageExtension.java
@@ -185,6 +185,7 @@ public class PostgreSQLStorageExtension extends AbstractStorageExtension
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 

--- a/actors/extensions/redis/src/main/java/com/ea/orbit/actors/extensions/redis/RedisStorageExtension.java
+++ b/actors/extensions/redis/src/main/java/com/ea/orbit/actors/extensions/redis/RedisStorageExtension.java
@@ -62,8 +62,10 @@ public class RedisStorageExtension extends AbstractStorageExtension
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+
         pool = new JedisPool(new JedisPoolConfig(), host, port, timeout);
         return Task.done();
     }

--- a/actors/extensions/redis/src/test/java/com/ea/orbit/actors/redis/test/RedisPersistenceTest.java
+++ b/actors/extensions/redis/src/test/java/com/ea/orbit/actors/redis/test/RedisPersistenceTest.java
@@ -72,8 +72,10 @@ public class RedisPersistenceTest extends StorageBaseTest
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
+
         databaseName = "" + (int) (Math.random() * Integer.MAX_VALUE);
         database = new Jedis("localhost", 6379);
     }

--- a/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/FakeStorageExtension.java
+++ b/actors/test/actor-tests/src/main/java/com/ea/orbit/actors/test/FakeStorageExtension.java
@@ -64,10 +64,10 @@ public class FakeStorageExtension implements StorageExtension
         this.database = database;
         mapper.registerModule(new ActorReferenceModule(new ReferenceFactory()));
 
-
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
     }

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/JsonReferenceSerializationTest.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/JsonReferenceSerializationTest.java
@@ -119,6 +119,7 @@ public class JsonReferenceSerializationTest
         mapper.setVisibilityChecker(mapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                 .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
                 .withCreatorVisibility(JsonAutoDetect.Visibility.NONE));
 


### PR DESCRIPTION
Without setting withIsGetterVisibility to NONE methods beginning with is break jackson serialization / deserialization of actor states (json payload contains is... attribute and fails to write it back into the bean).

com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "challengeLost" (class