### PR TITLE
Actor Stage JMX Initial Implementation

### DIFF
--- a/actors/stage/src/main/java/com/ea/orbit/actors/StageMetricsMXBean.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/StageMetricsMXBean.java
@@ -1,0 +1,44 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors;
+
+/**
+ * Created by jefftheriault on 15-05-27.
+ */
+public interface StageMetricsMXBean
+{
+    long getLocalActorCount();
+
+    long getObserverInstanceCount();
+
+    long getRefusedExecutionCount();
+
+    long getMessagesReceivedCount();
+    long getMessagesHandledCount();
+}

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -85,8 +85,6 @@ public class Execution implements Runtime
     private Map<Class<?>, InterfaceDescriptor> descriptorMapByInterface = new HashMap<>();
     private Map<Integer, InterfaceDescriptor> descriptorMapByInterfaceId = new HashMap<>();
     private Map<EntryKey, ReferenceEntry> localActors = new ConcurrentHashMap<>();
-
-
     private Map<EntryKey, ActorObserver> observerInstances = new MapMaker().weakValues().makeMap();
     // from implementation to reference
     private Map<ActorObserver, ActorObserver> observerReferences = new MapMaker().weakKeys().makeMap();

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -85,6 +85,8 @@ public class Execution implements Runtime
     private Map<Class<?>, InterfaceDescriptor> descriptorMapByInterface = new HashMap<>();
     private Map<Integer, InterfaceDescriptor> descriptorMapByInterfaceId = new HashMap<>();
     private Map<EntryKey, ReferenceEntry> localActors = new ConcurrentHashMap<>();
+
+
     private Map<EntryKey, ActorObserver> observerInstances = new MapMaker().weakValues().makeMap();
     // from implementation to reference
     private Map<ActorObserver, ActorObserver> observerReferences = new MapMaker().weakKeys().makeMap();
@@ -1189,5 +1191,27 @@ public class Execution implements Runtime
     public NodeCapabilities.NodeState getState()
     {
         return state;
+    }
+
+    public long getLocalActorCount()
+    {
+        return localActors.size();
+    }
+
+    public long getObserverInstanceCount() { return observerInstances.size(); }
+
+    public long getMessagesReceivedCount()
+    {
+        return messagesReceived.get();
+    }
+
+    public long getMessagesHandledCount()
+    {
+        return messagesHandled.get();
+    }
+
+    public long getRefusedExecutionsCount()
+    {
+        return refusedExecutions.get();
     }
 }


### PR DESCRIPTION
First pass at exposing some Actor Stage metrics via JMX.

With this PR, stages will expose Local Actor count, Observer Instance Count, Number of messages received, handled, and the number of refused executions. 

It publishes these metrics via JMX. You can use jconsole to see these values and you can also use a variety of tools to move this data into other tools like Graphite. 