### PR TITLE
Ensure change state notifications are sent before shutting down the executor.

### DIFF
--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -478,7 +478,7 @@ public class Execution implements Runtime
     {
         // * refuse new actor activations
         state = NodeCapabilities.NodeState.STOPPING;
-        hosting.notifyStateChange();
+        hosting.notifyStateChange().join();
 
         // * deactivate all actors
         activationCleanup().join();
@@ -489,10 +489,10 @@ public class Execution implements Runtime
         // * stop processing new received messages (responses still work)
         // * notify rest of the cluster (no more observer messages)
         state = NodeCapabilities.NodeState.STOPPED;
-        hosting.notifyStateChange();
+        hosting.notifyStateChange().join();
 
         // * wait pending tasks execution
-        executionSerializer.shutDown();
+        executionSerializer.shutdown();
 
         // ** stop all extensions
         Task.allOf(extensions.stream().map(v -> v.stop())).join();

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/ExecutionSerializer.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/ExecutionSerializer.java
@@ -161,7 +161,7 @@ public class ExecutionSerializer<T>
         }
     }
 
-    public void shutDown()
+    public void shutdown()
     {
         executorService.shutdown();
     }

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Hosting.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Hosting.java
@@ -109,12 +109,10 @@ public class Hosting implements NodeCapabilities, Startable
         return Collections.unmodifiableList(set);
     }
 
-    public void notifyStateChange()
+    public Task<?> notifyStateChange()
     {
-        for (NodeInfo info : activeNodes.values())
-        {
-            info.nodeCapabilities.nodeModeChanged(clusterPeer.localAddress(), execution.getState());
-        }
+        return Task.allOf(activeNodes.values().stream().map(info ->
+                info.nodeCapabilities.nodeModeChanged(clusterPeer.localAddress(), execution.getState())));
     }
 
     private static class NodeInfo

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/NodeCapabilities.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/NodeCapabilities.java
@@ -29,7 +29,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.ea.orbit.actors.runtime;
 
 import com.ea.orbit.actors.ActorObserver;
-import com.ea.orbit.actors.annotation.OneWay;
 import com.ea.orbit.actors.cluster.NodeAddress;
 import com.ea.orbit.concurrent.Task;
 
@@ -55,6 +54,5 @@ public interface NodeCapabilities extends ActorObserver
      */
     Task<Integer> canActivate(String interfaceName, int interfaceId);
 
-    @OneWay
     Task<Void> nodeModeChanged(NodeAddress nodeAddress, NodeState newMode);
 }


### PR DESCRIPTION
Ensure change state notifications are sent before shutting down the executor.

Motivation:

When shutting down an Orbit node the STOPPED state is never sent.

Modifications:

During shutdown sequence we now wait for the change state notifications to be sent before shutting down the executor.

2015-05-31 12:49:41,213 ERROR [ForkJoinPool-2-worker-441] (com.ea.orbit.actors.runtime.Messaging) Error processing message.
java.util.concurrent.RejectedExecutionException
	at java.util.concurrent.ForkJoinPool.fullExternalPush(ForkJoinPool.java:1531)
	at java.util.concurrent.ForkJoinPool.externalPush(ForkJoinPool.java:1501)

Result:

Improved graceful shutdown of Orbit nodes.