### PR TITLE
Using the intended cluster name instead of the default one

### DIFF
--- a/actors/stage/src/main/java/com/ea/orbit/actors/cluster/JGroupsClusterPeer.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/cluster/JGroupsClusterPeer.java
@@ -148,7 +148,7 @@ public class JGroupsClusterPeer implements ClusterPeer
                             true,
                             ProtocolStack.ABOVE,
                             FRAG2.class);
-                    channel.connect(clusterName + "." + UUID.randomUUID());
+                    channel.connect(clusterName);
 
                     channel.setReceiver(new ReceiverAdapter()
                     {
@@ -169,7 +169,7 @@ public class JGroupsClusterPeer implements ClusterPeer
 
                     final GlobalConfigurationBuilder globalConfigurationBuilder = GlobalConfigurationBuilder.defaultClusteredBuilder();
                     globalConfigurationBuilder.globalJmxStatistics().allowDuplicateDomains(true);
-                    globalConfigurationBuilder.transport().nodeName(nodeName).transport(new JGroupsTransport(baseChannel));
+                    globalConfigurationBuilder.transport().clusterName(clusterName).nodeName(nodeName).transport(new JGroupsTransport(baseChannel));
 
                     ConfigurationBuilder builder = new ConfigurationBuilder();
                     builder.clustering().cacheMode(CacheMode.DIST_ASYNC);


### PR DESCRIPTION
l. 172: adding call to TransportConfigurationBuilder.clusterName
- using the clusterName defined in the orbit.yaml instead of the default Infinispan one
- as discussed in Gitter, using the default one was not done on purpose, so I suggest setting the intended one

l. 151: removed UUID call
- since ForkChannel.connect ignores the parameter one provides, appending a random UUID to it is superfluous and a waste of processing power