### PR TITLE
MetricsRegistry accessor access level fix.

### DIFF
--- a/utils/metrics/metrics/src/main/java/com/ea/orbit/metrics/MetricsManager.java
+++ b/utils/metrics/metrics/src/main/java/com/ea/orbit/metrics/MetricsManager.java
@@ -74,7 +74,7 @@ public class MetricsManager
         return nameSanitizationRegex.matcher(name).replaceAll(""); //strip illegal characters
     }
 
-    public MetricRegistry getRegistry()
+    protected MetricRegistry getRegistry()
     {
         return registry;
     }


### PR DESCRIPTION
The getRegistry() method on MetricsManager was accidentally left public. It should only be accessible within the Metrics package so that we don't leak dropwizard specific types outside the package.