### PR TITLE
Allow setting of sticky headers.

### DIFF
--- a/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
@@ -56,8 +56,11 @@ import javax.inject.Singleton;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
@@ -65,6 +68,8 @@ import java.util.stream.Collectors;
 public class Stage implements Startable
 {
     private static final Logger logger = LoggerFactory.getLogger(Stage.class);
+
+    private static final int DEFAULT_EXECUTION_POOL_SIZE = 128;
 
     @Config("orbit.actors.clusterName")
     private String clusterName;
@@ -76,10 +81,13 @@ public class Stage implements Startable
     private StageMode mode = StageMode.HOST;
 
     @Config("orbit.actors.executionPoolSize")
-    private int executionPoolSize = 128;
+    private int executionPoolSize = DEFAULT_EXECUTION_POOL_SIZE;
 
     @Config("orbit.actors.extensions")
     private List<ActorExtension> extensions = new ArrayList<>();
+
+    @Config("orbit.actors.stickyHeaders")
+    private Set<String> stickyHeaders = new HashSet<>();
 
     @Wired
     private Container container;
@@ -126,14 +134,107 @@ public class Stage implements Startable
         }
     }
 
+    public static class Builder {
+
+        private Clock clock;
+        private ExecutorService executionPool;
+        private ExecutorService messagingPool;
+        private ExecutionObjectCloner objectCloner;
+        private ClusterPeer clusterPeer;
+
+        private String clusterName;
+        private String nodeName;
+        private StageMode mode = StageMode.HOST;
+        private int executionPoolSize = DEFAULT_EXECUTION_POOL_SIZE;
+
+        private Messaging messaging;
+
+        private List<ActorExtension> extensions = new ArrayList<>();
+        private Set<String> stickyHeaders = new HashSet<>();
+
+        public Builder clock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        public Builder executionPool(ExecutorService executionPool) {
+            this.executionPool = executionPool;
+            return this;
+        }
+
+        public Builder messagingPool(ExecutorService messagingPool) {
+            this.messagingPool = messagingPool;
+            return this;
+        }
+
+        public Builder clusterPeer(ClusterPeer clusterPeer) {
+            this.clusterPeer = clusterPeer;
+            return this;
+        }
+
+        public Builder objectCloner(ExecutionObjectCloner objectCloner) {
+            this.objectCloner = objectCloner;
+            return this;
+        }
+
+        public Builder clusterName(String clusterName) {
+            this.clusterName = clusterName;
+            return this;
+        }
+
+        public Builder nodeName(String nodeName) {
+            this.nodeName = nodeName;
+            return this;
+        }
+
+        public Builder mode(StageMode mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder messaging(Messaging messaging) {
+            this.messaging = messaging;
+            return this;
+        }
+
+        public Builder extensions(ActorExtension ...extensions)
+        {
+            Collections.addAll(this.extensions, extensions);
+            return this;
+        }
+
+        public Builder stickyHeaders(String ...stickyHeaders)
+        {
+            Collections.addAll(this.stickyHeaders, stickyHeaders);
+            return this;
+        }
+
+        public Stage build() {
+            Stage stage = new Stage();
+            stage.setClock(clock);
+            stage.setExecutionPool(executionPool);
+            stage.setMessagingPool(messagingPool);
+            stage.setObjectCloner(objectCloner);
+            stage.setClusterName(clusterName);
+            stage.setNodeName(nodeName);
+            stage.setMode(mode);
+            stage.setExecutionPoolSize(executionPoolSize);
+            extensions.forEach(stage::addExtension);
+            stage.setMessaging(messaging);
+            stage.addStickyHeaders(stickyHeaders);
+            return stage;
+        }
+
+    }
+
+    public void addStickyHeaders(Collection<String> stickyHeaders)
+    {
+        this.stickyHeaders.addAll(stickyHeaders);
+    }
+
     public void setClock(final Clock clock)
     {
         this.clock = clock;
-    }
-
-    public void setExecution(final Execution execution)
-    {
-        this.execution = execution;
     }
 
     public void setMessaging(final Messaging messaging)
@@ -269,7 +370,7 @@ public class Stage implements Startable
         {
             if (container != null)
             {
-                if (clusterPeer == null && !container.getClasses().stream().filter(ClusterPeer.class::isAssignableFrom).findAny().isPresent())
+                if (!container.getClasses().stream().filter(ClusterPeer.class::isAssignableFrom).findAny().isPresent())
                 {
                     clusterPeer = container.get(JGroupsClusterPeer.class);
                 }
@@ -306,6 +407,7 @@ public class Stage implements Startable
         execution.setMessaging(messaging);
         execution.setExecutor(executionPool);
         execution.setObjectCloner(objectCloner);
+        execution.addStickyHeaders(stickyHeaders);
 
         messaging.setExecution(execution);
         messaging.setClock(clock);

--- a/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
@@ -111,7 +111,7 @@ public class Stage implements Startable
             try
             {
                 // async is present in the classpath, let's make sure await is initialized
-                Class.forName("com.ea.orbit.async.Await").getMethod("init").invoke(null);;
+                Class.forName("com.ea.orbit.async.Await").getMethod("init").invoke(null);
             }
             catch(Exception ex)
             {
@@ -129,6 +129,11 @@ public class Stage implements Startable
     public void setClock(final Clock clock)
     {
         this.clock = clock;
+    }
+
+    public void setExecution(final Execution execution)
+    {
+        this.execution = execution;
     }
 
     public void setMessaging(final Messaging messaging)

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -55,6 +55,7 @@ import com.ea.orbit.tuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 
 import java.io.IOException;
@@ -136,7 +137,7 @@ public class Execution implements Runtime
      * RPC message headers that are copied from and to the TaskContext.
      * <p>
      * These fields are copied from the TaskContext to the message headers when sending messagess.
-     * And from the message header to the TaskContext when receiving them.ø
+     * And from the message header to the TaskContext when receiving them.
      * </p>
      */
     @Config("orbit.actors.stickyHeaders")
@@ -493,6 +494,15 @@ public class Execution implements Runtime
         }
     }
 
+    public void addStickerHeaders(String ...stickyHeaders)
+    {
+        Collections.addAll(this.stickyHeaders, stickyHeaders);
+    }
+
+    public Set<String> getStickyHeaders()
+    {
+        return ImmutableSet.copyOf(stickyHeaders);
+    }
 
     public void setExtensions(List<ActorExtension> extensions)
     {

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -43,7 +43,6 @@ import com.ea.orbit.actors.extensions.LifetimeExtension;
 import com.ea.orbit.actors.runtime.cloner.ExecutionObjectCloner;
 import com.ea.orbit.actors.transactions.TransactionUtils;
 import com.ea.orbit.annotation.CacheResponse;
-import com.ea.orbit.annotation.Config;
 import com.ea.orbit.annotation.OnlyIfActivated;
 import com.ea.orbit.concurrent.ExecutorUtils;
 import com.ea.orbit.concurrent.Task;
@@ -55,7 +54,6 @@ import com.ea.orbit.tuples.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 
 import java.io.IOException;
@@ -70,6 +68,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -140,7 +139,6 @@ public class Execution implements Runtime
      * And from the message header to the TaskContext when receiving them.
      * </p>
      */
-    @Config("orbit.actors.stickyHeaders")
     private Set<String> stickyHeaders = new HashSet<>(Arrays.asList(TransactionUtils.ORBIT_TRANSACTION_ID, "orbit.traceId"));
 
     public Execution()
@@ -494,14 +492,9 @@ public class Execution implements Runtime
         }
     }
 
-    public void addStickerHeaders(String ...stickyHeaders)
+    public void addStickyHeaders(Collection<String> stickyHeaders)
     {
-        Collections.addAll(this.stickyHeaders, stickyHeaders);
-    }
-
-    public Set<String> getStickyHeaders()
-    {
-        return ImmutableSet.copyOf(stickyHeaders);
+        this.stickyHeaders.addAll(stickyHeaders);
     }
 
     public void setExtensions(List<ActorExtension> extensions)


### PR DESCRIPTION
Motivation:

Currently the only way to set sticky headers is to use Orbit Container, it should be possible to set them when setting up Stage too.

Modification:

Add setter for execution and allow adding sticky headers to Execution.

Result:

Sticky headers can be set programmatically.