### PR TITLE
Remove dependency of orbit-agent-loader from orbit-actors-core

### DIFF
--- a/actors/core/src/main/java/com/ea/orbit/actors/runtime/ReferenceFactory.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/runtime/ReferenceFactory.java
@@ -34,7 +34,7 @@ import com.ea.orbit.actors.Addressable;
 import com.ea.orbit.actors.annotation.NoIdentity;
 import com.ea.orbit.actors.annotation.OneWay;
 import com.ea.orbit.actors.cluster.NodeAddressImpl;
-import com.ea.orbit.instrumentation.ClassPathUtils;
+import com.ea.orbit.util.ClassPath;
 
 import java.lang.reflect.Proxy;
 import java.util.UUID;
@@ -80,7 +80,7 @@ public class ReferenceFactory implements RefFactory
                 {
                     factoryClazz = factoryClazz.substring(1); // remove leading 'I'
                 }
-                factory = (ActorFactory<T>) Class.forName(ClassPathUtils.getNullSafePackageName(iClass) + "." + factoryClazz).newInstance();
+                factory = (ActorFactory<T>) Class.forName(ClassPath.getNullSafePackageName(iClass) + "." + factoryClazz).newInstance();
             }
             catch (Exception e)
             {

--- a/commons/src/main/java/com/ea/orbit/util/ClassPath.java
+++ b/commons/src/main/java/com/ea/orbit/util/ClassPath.java
@@ -219,4 +219,9 @@ public class ClassPath
         return res;
     }
 
+    public static String getNullSafePackageName(final Class<?> clazz)
+    {
+        return clazz.getPackage() != null ? clazz.getPackage().getName() : "";
+    }
+
 }

--- a/container/src/main/java/com/ea/orbit/container/Module.java
+++ b/container/src/main/java/com/ea/orbit/container/Module.java
@@ -29,7 +29,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.ea.orbit.container;
 
 import com.ea.orbit.exception.UncheckedException;
-import com.ea.orbit.instrumentation.ClassPathUtils;
 import com.ea.orbit.util.ClassPath;
 import javax.inject.Singleton;
 
@@ -76,7 +75,7 @@ public class Module
         }
         else
         {
-            String packageName = ClassPathUtils.getNullSafePackageName(getClass()).replace('.', '/');
+            String packageName = ClassPath.getNullSafePackageName(getClass()).replace('.', '/');
             return ClassPath.get().getAllResources().stream()
                     .filter(r -> r.getResourceName().startsWith(packageName))
                     .filter(r -> r.getResourceName().endsWith(".class"))

--- a/utils/agent-loader/src/main/java/com/ea/orbit/instrumentation/ClassPathUtils.java
+++ b/utils/agent-loader/src/main/java/com/ea/orbit/instrumentation/ClassPathUtils.java
@@ -87,11 +87,6 @@ public class ClassPathUtils
         }
     }
 
-    public static String getNullSafePackageName(final Class<?> clazz)
-    {
-        return clazz.getPackage() != null ? clazz.getPackage().getName() : "";
-    }
-
     /**
      * Get the actual classpath resource location for a class
      *


### PR DESCRIPTION
Motivation:

If you use compile time instrumentation for orbit-async and then remove it from the classpath orbit-agent-loader is not on the classpath either and the application will blow up with ClassNotFoundException as ClassPathUtils is used here com.ea.orbit.actors.runtime.ReferenceFactory#getFactory in orbit-actors-core

Modification:

Move getNullSafePackageName to ClassPath util class in orbit-commons.

Result:

Orbit applications can run with compile time async instrumented code without orbit-async and orbit-agent-loader.