### PR TITLE
Added JAX-RS/JSON support to Orbit Web

### DIFF
--- a/container/src/main/java/com/ea/orbit/container/Container.java
+++ b/container/src/main/java/com/ea/orbit/container/Container.java
@@ -140,7 +140,7 @@ public class Container
         int order;
     }
 
-    protected enum ContainerState
+    public enum ContainerState
     {
         CREATED,
         STARTING,
@@ -560,5 +560,7 @@ public class Container
         }
         return list;
     }
+
+    public ContainerState getContainerState() { return state; }
 
 }

--- a/utils/rest-client/pom.xml
+++ b/utils/rest-client/pom.xml
@@ -95,18 +95,5 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>${jackson.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -100,8 +100,14 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-moxy</artifactId>
+            <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey.version}</version>
         </dependency>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -100,6 +100,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-moxy</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/web/src/main/java/com/ea/orbit/web/EmbeddedHttpServer.java
+++ b/web/src/main/java/com/ea/orbit/web/EmbeddedHttpServer.java
@@ -108,7 +108,8 @@ public class EmbeddedHttpServer implements Startable
             classes.addAll(container.getClasses());
             for (final Class<?> c : container.getClasses())
             {
-                if (c.isAnnotationPresent(Singleton.class))
+                // Is a singleton or container itself?
+                if (c.isAnnotationPresent(Singleton.class) || c == Container.class)
                 {
                     Injections.addBinding(
                             Injections.newFactoryBinder(new Factory()

--- a/web/src/main/java/com/ea/orbit/web/diagnostics/DiagnosticsHandler.java
+++ b/web/src/main/java/com/ea/orbit/web/diagnostics/DiagnosticsHandler.java
@@ -1,0 +1,62 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.web.diagnostics;
+
+import com.ea.orbit.container.Container;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import java.util.Date;
+
+@Path("/orbit/diagnostics")
+public class DiagnosticsHandler
+{
+    @Inject
+    Container orbitContainer;
+
+    public static class HealthcheckResult
+    {
+        public Boolean alive = true;
+        public Date serverTime = new Date();
+    }
+
+    @GET
+    @Path("/healthcheck")
+    @Produces(MediaType.APPLICATION_JSON)
+    public HealthcheckResult getHealthCheck()
+    {
+        final HealthcheckResult healthcheckResult = new HealthcheckResult();
+        healthcheckResult.alive = orbitContainer.getContainerState() == Container.ContainerState.STARTED;
+        return new HealthcheckResult();
+    }
+}

--- a/web/src/main/java/com/ea/orbit/web/diagnostics/DiagnosticsHandler.java
+++ b/web/src/main/java/com/ea/orbit/web/diagnostics/DiagnosticsHandler.java
@@ -46,8 +46,28 @@ public class DiagnosticsHandler
 
     public static class HealthcheckResult
     {
-        public Boolean alive = true;
-        public Date serverTime = new Date();
+        private Boolean alive = true;
+        private Date serverTime = new Date();
+
+        public Boolean getAlive()
+        {
+            return alive;
+        }
+
+        public void setAlive(Boolean alive)
+        {
+            this.alive = alive;
+        }
+
+        public Date getServerTime()
+        {
+            return serverTime;
+        }
+
+        public void setServerTime(Date serverTime)
+        {
+            this.serverTime = serverTime;
+        }
     }
 
     @GET
@@ -56,7 +76,7 @@ public class DiagnosticsHandler
     public HealthcheckResult getHealthCheck()
     {
         final HealthcheckResult healthcheckResult = new HealthcheckResult();
-        healthcheckResult.alive = orbitContainer.getContainerState() == Container.ContainerState.STARTED;
+        healthcheckResult.setAlive(orbitContainer.getContainerState() == Container.ContainerState.STARTED);
         return healthcheckResult;
     }
 }

--- a/web/src/main/java/com/ea/orbit/web/diagnostics/DiagnosticsHandler.java
+++ b/web/src/main/java/com/ea/orbit/web/diagnostics/DiagnosticsHandler.java
@@ -57,6 +57,6 @@ public class DiagnosticsHandler
     {
         final HealthcheckResult healthcheckResult = new HealthcheckResult();
         healthcheckResult.alive = orbitContainer.getContainerState() == Container.ContainerState.STARTED;
-        return new HealthcheckResult();
+        return healthcheckResult;
     }
 }


### PR DESCRIPTION
This change means that JAX-RS will work out of the box and have support for JSON.
I added a default healthcheck API as an example.
Finally, I tweaked the Embedded HTTP server so Orbit Container is also injectable via JAX-RS/Jersey/HK2.