### PR TITLE
Re-implementing Stage/Messaging Metrics as Pipeline Extension

### DIFF
--- a/actors/extensions/metrics/pom.xml
+++ b/actors/extensions/metrics/pom.xml
@@ -48,6 +48,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </dependency>
         <dependency>
             <groupId>com.ea.orbit</groupId>
+            <artifactId>orbit-actors-stage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ea.orbit</groupId>
             <artifactId>orbit-metrics</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/actors/extensions/metrics/src/main/java/com/ea/orbit/actors/extensions/metrics/MetricsPipelineExtension.java
+++ b/actors/extensions/metrics/src/main/java/com/ea/orbit/actors/extensions/metrics/MetricsPipelineExtension.java
@@ -108,7 +108,9 @@ public class MetricsPipelineExtension extends NamedPipelineExtension
             Meter messageMeter = receiveMeters.get(messageType);
 
             if (messageMeter != null)
+            {
                 messageMeter.mark();
+            }
         }
 
         ctx.fireRead(message);
@@ -126,14 +128,16 @@ public class MetricsPipelineExtension extends NamedPipelineExtension
             Meter messageMeter = sendMeters.get(messageType);
 
             if (messageMeter != null)
+            {
                 messageMeter.mark();
+            }
         }
 
-        return super.write(ctx, message);
+        return ctx.write(message);
     }
 
     @ExportMetric(name="messagesReceived")
-    public int getMessagesRecievedCount()
+    public int getMessagesReceivedCount()
     {
         return messagesReceived.intValue();
     }

--- a/actors/extensions/metrics/src/main/java/com/ea/orbit/actors/extensions/metrics/MetricsPipelineExtension.java
+++ b/actors/extensions/metrics/src/main/java/com/ea/orbit/actors/extensions/metrics/MetricsPipelineExtension.java
@@ -1,0 +1,146 @@
+/*
+ Copyright (C) 2015 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.orbit.actors.extensions.metrics;
+
+import com.ea.orbit.actors.extensions.NamedPipelineExtension;
+import com.ea.orbit.actors.net.HandlerContext;
+import com.ea.orbit.actors.runtime.DefaultHandlers;
+import com.ea.orbit.actors.runtime.Message;
+import com.ea.orbit.actors.runtime.MessageDefinitions;
+import com.ea.orbit.concurrent.Task;
+import com.ea.orbit.metrics.MetricsManager;
+import com.ea.orbit.metrics.annotations.ExportMetric;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Meter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Created by Jeff on 12/1/2015.
+ */
+public class MetricsPipelineExtension extends NamedPipelineExtension
+{
+    public static final String METRICS_PIPELINE_NAME = "metrics-messaging-pipeline";
+
+    private Logger logger = LoggerFactory.getLogger(MetricsPipelineExtension.class);
+
+    private LongAdder messagesReceived = new LongAdder();
+    private LongAdder messagesSent = new LongAdder();
+
+    private Map<Integer, Meter> receiveMeters = new HashMap<>();
+    private Map<Integer, Meter> sendMeters = new HashMap<>();
+
+    public MetricsPipelineExtension()
+    {
+        super(METRICS_PIPELINE_NAME, null, DefaultHandlers.MESSAGING);
+        setupMetrics();
+    }
+
+    public MetricsPipelineExtension(final String name, final String beforeHandlerName, final String afterHandlerName)
+    {
+        super(name, beforeHandlerName, afterHandlerName);
+        setupMetrics();
+    }
+
+    private void setupMetrics()
+    {
+        setupMeterForMessageType(receiveMeters, "one-way-message-receive-rate", (int)MessageDefinitions.ONE_WAY_MESSAGE);
+        setupMeterForMessageType(receiveMeters, "request-message-receive-rate", (int)MessageDefinitions.REQUEST_MESSAGE);
+        setupMeterForMessageType(receiveMeters, "response-error-receive-rate", (int)MessageDefinitions.RESPONSE_ERROR);
+        setupMeterForMessageType(receiveMeters, "response-ok-receive-rate", (int)MessageDefinitions.RESPONSE_OK);
+        setupMeterForMessageType(receiveMeters, "response-protocol-error-receive-rate", (int)MessageDefinitions.RESPONSE_PROTOCOL_ERROR);
+        setupMeterForMessageType(sendMeters, "one-way-message-send-rate", (int)MessageDefinitions.ONE_WAY_MESSAGE);
+        setupMeterForMessageType(sendMeters, "request-message-send-rate", (int)MessageDefinitions.REQUEST_MESSAGE);
+        setupMeterForMessageType(sendMeters, "response-error-send-rate", (int)MessageDefinitions.RESPONSE_ERROR);
+        setupMeterForMessageType(sendMeters, "response-ok-send-rate", (int)MessageDefinitions.RESPONSE_OK);
+        setupMeterForMessageType(sendMeters, "response-protocol-error-send-rate", (int)MessageDefinitions.RESPONSE_PROTOCOL_ERROR);
+
+        MetricsManager.getInstance().registerExportedMetrics(this);
+    }
+
+    private void setupMeterForMessageType(Map<Integer, Meter> meters, String name, int messageType)
+    {
+        Meter meter = new Meter();
+        meters.put(messageType, meter);
+        MetricsManager.getInstance().registerMetric(name, meter);
+    }
+
+    @Override
+    public void onRead(HandlerContext ctx, Object message)
+    {
+        if (message instanceof Message)
+        {
+            messagesReceived.increment();
+
+            Message msg = (Message) message;
+            final int messageType = msg.getMessageType();
+            Meter messageMeter = receiveMeters.get(messageType);
+
+            if (messageMeter != null)
+                messageMeter.mark();
+        }
+
+        ctx.fireRead(message);
+    }
+
+    @Override
+    public Task write(HandlerContext ctx, Object message) throws Exception
+    {
+        if (message instanceof Message)
+        {
+            messagesSent.increment();
+
+            Message msg = (Message) message;
+            final int messageType = msg.getMessageType();
+            Meter messageMeter = sendMeters.get(messageType);
+
+            if (messageMeter != null)
+                messageMeter.mark();
+        }
+
+        return super.write(ctx, message);
+    }
+
+    @ExportMetric(name="messagesReceived")
+    public int getMessagesRecievedCount()
+    {
+        return messagesReceived.intValue();
+    }
+
+    @ExportMetric(name="messagesSent")
+    public int getMessagesSentCount()
+    {
+        return messagesSent.intValue();
+    }
+}

--- a/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
@@ -84,6 +84,7 @@ import com.ea.orbit.concurrent.Task;
 import com.ea.orbit.container.Container;
 import com.ea.orbit.container.Startable;
 import com.ea.orbit.exception.UncheckedException;
+import com.ea.orbit.metrics.annotations.ExportMetric;
 import com.ea.orbit.util.StringUtils;
 
 import org.slf4j.Logger;
@@ -1224,5 +1225,17 @@ public class Stage implements Startable, ActorRuntime
                 "state=" + state +
                 ", runtimeIdentity='" + runtimeIdentity + '\'' +
                 '}';
+    }
+
+    @ExportMetric(name="localActorCount")
+    public int getLocalActorCount()
+    {
+        int value = 0;
+        if (execution != null)
+        {
+            value = execution.getObjectCount();
+        }
+
+        return value;
     }
 }

--- a/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/Stage.java
@@ -1230,12 +1230,6 @@ public class Stage implements Startable, ActorRuntime
     @ExportMetric(name="localActorCount")
     public int getLocalActorCount()
     {
-        int value = 0;
-        if (execution != null)
-        {
-            value = execution.getObjectCount();
-        }
-
-        return value;
+        return objects.getLocalObjectCount();
     }
 }

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -164,9 +164,4 @@ public class Execution extends AbstractExecution implements Startable
         this.objects = objects;
     }
 
-    public int getObjectCount()
-    {
-        return objects.getLocalObjectCount();
-    }
-
 }

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/Execution.java
@@ -164,4 +164,9 @@ public class Execution extends AbstractExecution implements Startable
         this.objects = objects;
     }
 
+    public int getObjectCount()
+    {
+        return objects.getLocalObjectCount();
+    }
+
 }

--- a/actors/stage/src/main/java/com/ea/orbit/actors/runtime/LocalObjects.java
+++ b/actors/stage/src/main/java/com/ea/orbit/actors/runtime/LocalObjects.java
@@ -313,5 +313,8 @@ public class LocalObjects
         return localObjects.values().stream();
     }
 
-
+    public int getLocalObjectCount()
+    {
+        return localObjects.size();
+    }
 }

--- a/samples/chat/chat-actors/src/main/resources/conf/orbit.yaml
+++ b/samples/chat/chat-actors/src/main/resources/conf/orbit.yaml
@@ -35,6 +35,7 @@ orbit.actors.extensions:
     port: 27017
     database: chat
   - !!com.ea.orbit.actors.extensions.metrics.MetricsLifetimeExtension {}
+  - !!com.ea.orbit.actors.extensions.metrics.MetricsPipelineExtension {}
 
 orbit.chat.maxMessages: 500
 

--- a/utils/metrics/metrics/src/main/java/com/ea/orbit/metrics/MetricsManager.java
+++ b/utils/metrics/metrics/src/main/java/com/ea/orbit/metrics/MetricsManager.java
@@ -256,7 +256,7 @@ public class MetricsManager
 
         if (obj != null)
         {
-            for (Field field : obj.getClass().getDeclaredFields())
+            for (Field field : obj.getClass().getFields())
             {
                 if (field.isAnnotationPresent(ExportMetric.class))
                 {
@@ -274,7 +274,7 @@ public class MetricsManager
 
         if (obj != null)
         {
-            for (Method method : obj.getClass().getDeclaredMethods())
+            for (Method method : obj.getClass().getMethods())
             {
                 if (method.isAnnotationPresent(ExportMetric.class))
                 {


### PR DESCRIPTION
* I've added back localActorCount back via Stage and execution since I didn't see an easy way to expose this information from an extension.

* Created a new Pipeline Extension for measuring Message Rates. It logs number of messages sent and received from a node along with rates of each message type in both directions. (Allows for monitoring error rates etc) 

* Fixed an issue in automatic metric registration where inherited metrics were not being registered.