### PR TITLE
Actor method annotated with CacheResponse which returns null will thr…

### DIFF
--- a/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/cloner/CloneHelper.java
+++ b/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/cloner/CloneHelper.java
@@ -74,14 +74,21 @@ public class CloneHelper
             java.net.InetSocketAddress.class
     ));
 
-    public static boolean needsCloning(Object payload) {
-        if (payload instanceof Message) {
-            return needsCloning((Message) payload);
+    public static boolean needsCloning(Object object)
+    {
+        if (object == null)
+        {
+            return false;
         }
-        return !payload.getClass().isAnnotationPresent(Immutable.class) && !IMMUTABLES.contains(payload.getClass());
+        if (object instanceof Message)
+        {
+            return needsCloning((Message) object);
+        }
+        return !isObjectConsideredImmutable(object);
     }
 
-    private static boolean needsCloning(Message message) {
+    private static boolean needsCloning(Message message)
+    {
         // this can be improved by looking into the
         // argument/return types of ClassId.MethodId and caching the decision.
 
@@ -100,7 +107,7 @@ public class CloneHelper
                     for (int i = arr.length; --i >= 0; )
                     {
                         Object obj = arr[i];
-                        if (obj != null && !obj.getClass().isAnnotationPresent(Immutable.class) && !IMMUTABLES.contains(obj.getClass()))
+                        if (!isObjectConsideredImmutable(obj))
                         {
                             return true;
                         }
@@ -111,12 +118,33 @@ public class CloneHelper
                 break;
             case MessageDefinitions.RESPONSE_OK:
                 // already test for null in the beginning of the method.
-                if (payload.getClass().isAnnotationPresent(Immutable.class) || IMMUTABLES.contains(payload.getClass()))
+                if (isObjectConsideredImmutable(payload))
                 {
                     return false;
                 }
                 break;
         }
         return true;
+    }
+
+    private static boolean isObjectConsideredImmutable(Object object)
+    {
+        if (object == null)
+        {
+            return true;
+        }
+        if (object.getClass().isAnnotationPresent(Immutable.class))
+        {
+            return true;
+        }
+        if (IMMUTABLES.contains(object.getClass()))
+        {
+            return true;
+        }
+        if (object.getClass().isEnum())
+        {
+            return true;
+        }
+        return false;
     }
 }

--- a/actors/runtime/src/test/java/com/ea/orbit/actors/runtime/cloner/CloneHelperTest.java
+++ b/actors/runtime/src/test/java/com/ea/orbit/actors/runtime/cloner/CloneHelperTest.java
@@ -54,18 +54,27 @@ public class CloneHelperTest
     public void testMutableClasses() throws Exception
     {
         assertTrue(CloneHelper.needsCloning(new MutableClass()));
+        assertFalse(CloneHelper.needsCloning(ImmutableEnum.TEST));
+        assertFalse(CloneHelper.needsCloning(null));
     }
 
     @Test
     public void testMessageWithObjectArrayPayload() throws Exception
     {
-        assertFalse(CloneHelper.needsCloning(new Message().withPayload(new Object[]{1337L, "string"})));
-        assertTrue(CloneHelper.needsCloning(new Message().withPayload(new Object[]{new ImmutableClass("huuhaa"), new MutableClass()})));
-        assertFalse(CloneHelper.needsCloning(new Message().withPayload(new Object[]{new ImmutableClass("huuhaa"), new ImmutableClass("huuhaa")})));
+        assertFalse(CloneHelper.needsCloning(new Message().withPayload(new Object[]{ 1337L, "string" })));
+        assertTrue(CloneHelper.needsCloning(new Message().withPayload(new Object[]{ new ImmutableClass("huuhaa"), new MutableClass() })));
+        assertFalse(CloneHelper.needsCloning(new Message().withPayload(new Object[]{ new ImmutableClass("huuhaa"), new ImmutableClass("huuhaa") })));
+        assertFalse(CloneHelper.needsCloning(new Message().withPayload(new Object[]{ CloneHelperTest.ImmutableEnum.TEST })));
+    }
+
+    private enum ImmutableEnum
+    {
+        TEST
     }
 
     @Immutable
-    private class ImmutableClass {
+    private class ImmutableClass
+    {
         private final String id;
 
         public ImmutableClass(final String id)
@@ -74,7 +83,8 @@ public class CloneHelperTest
         }
     }
 
-    private class MutableClass {
+    private class MutableClass
+    {
         private String id;
     }
 }


### PR DESCRIPTION
…ow a hidden NPE.

Motivation:

If an actor method annotated with CacheResponse returns null it will throw a hidden NPE.

Modifications:

Fix possible NPE, add unit test and support for enums.

Result:

Actor method annotated with CacheResponse which returns null will no longer throw an NPE.