### PR TITLE
Allow actor implementations to hint to the system when the actor can …

### DIFF
--- a/actors/core/src/main/java/com/ea/orbit/actors/runtime/AbstractActor.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/runtime/AbstractActor.java
@@ -189,7 +189,6 @@ public abstract class AbstractActor<T>
      *
      * @param futureCallable a callable that returns a Task
      * @param dueTime        Time to the first timer call
-     * @param period         Interval between calls, if period <= 0 then the timer will be single shot.
      * @param timeUnit       Time unit for dueTime and period
      * @return A registration object that allows the actor to cancel the timer.
      */
@@ -264,6 +263,18 @@ public abstract class AbstractActor<T>
     public Task<?> deactivateAsync()
     {
         return Task.done();
+    }
+
+    /**
+     * Checks if this actor has "expired" and can be removed from the system.
+     *
+     * @param ttlExpired if the actors last access ttl has expired
+     * @return {@code true} if this actor has expired and can be removed
+     * from the system
+     */
+    public Task<Boolean> canBeRemoved(boolean ttlExpired)
+    {
+        return Task.fromValue(ttlExpired);
     }
 
     protected StreamProvider getStreamProvider(String name)

--- a/actors/core/src/main/java/com/ea/orbit/actors/runtime/ActorRuntime.java
+++ b/actors/core/src/main/java/com/ea/orbit/actors/runtime/ActorRuntime.java
@@ -149,4 +149,6 @@ public interface ActorRuntime extends BasicRuntime
 
     List<NodeAddress> getAllNodes();
 
+    long getDefaultActorTTL();
+
 }

--- a/actors/runtime/pom.xml
+++ b/actors/runtime/pom.xml
@@ -110,10 +110,5 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>javax.inject</artifactId>
             <version>1</version>
         </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-        </dependency>
     </dependencies>
 </project>

--- a/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/ActorBaseEntry.java
+++ b/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/ActorBaseEntry.java
@@ -108,6 +108,13 @@ public abstract class ActorBaseEntry<T extends AbstractActor> implements LocalOb
 
     public abstract Task<Void> deactivate();
 
+    /**
+     * Checks if this actor has "expired" and can be removed from the system.
+     *
+     * @return {@code true} if this actor has expired and can be removed
+     * from the system
+     */
+    public abstract Task<Boolean> canBeRemoved();
 
     public void setDeactivated(final boolean deactivated)
     {
@@ -117,5 +124,10 @@ public abstract class ActorBaseEntry<T extends AbstractActor> implements LocalOb
     public long getLastAccess()
     {
         return lastAccess;
+    }
+
+    public boolean hasTTLExpired()
+    {
+        return runtime.clock().millis() - getLastAccess() > runtime.getDefaultActorTTL();
     }
 }

--- a/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/ActorEntry.java
+++ b/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/ActorEntry.java
@@ -164,13 +164,34 @@ public class ActorEntry<T extends AbstractActor> extends ActorBaseEntry<T>
             {
                 return Task.done();
             }
-            return executionSerializer.offerJob(key, () -> doDeactivate(), 1000);
+            return executionSerializer.offerJob(key, () -> doDeactivate(), 10000);
         }
         catch (Throwable ex)
         {
             // this should never happen, but deactivate must't fail.
             ex.printStackTrace();
             return Task.done();
+        }
+    }
+
+    @Override
+    public Task<Boolean> canBeRemoved()
+    {
+        try
+        {
+            if (isDeactivated())
+            {
+                return Task.fromValue(true);
+            }
+            return executionSerializer.offerJob(key, () -> {
+                return actor.canBeRemoved(hasTTLExpired());
+            }, 10000);
+        }
+        catch (Throwable ex)
+        {
+            // this should never happen, but canBeRemoved must't fail.
+            ex.printStackTrace();
+            return Task.fromValue(true);
         }
     }
 

--- a/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/StatelessActorEntry.java
+++ b/actors/runtime/src/main/java/com/ea/orbit/actors/runtime/StatelessActorEntry.java
@@ -115,6 +115,11 @@ public class StatelessActorEntry<T extends AbstractActor> extends ActorBaseEntry
         return Task.done();
     }
 
+    @Override
+    public Task<Boolean> canBeRemoved()
+    {
+        return Task.fromValue(hasTTLExpired());
+    }
 
     ActorEntry<T> tryPop()
     {

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/DeactivationTest.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/DeactivationTest.java
@@ -66,6 +66,26 @@ public class DeactivationTest extends ClientTest
         dumpMessages();
     }
 
+    @Test
+    public void customCleanupTest() throws ExecutionException, InterruptedException
+    {
+        loggerExtension.enableDebugFor(Stage.class);
+        clock.stop();
+        Stage stage = createStage();
+        SomeActor actor1 = Actor.getReference(SomeActor.class, "1000");
+
+        final UUID id = actor1.getUniqueActivationId().join();
+        actor1.setCanBeRemoved(false).join();
+        clock.incrementTime(20, TimeUnit.MINUTES);
+        stage.cleanup().join();
+        assertEquals(id, actor1.getUniqueActivationId().join());
+        actor1.setCanBeRemoved(true).join();
+        clock.incrementTime(20, TimeUnit.MINUTES);
+        stage.cleanup().join();
+        assertNotEquals(id, actor1.getUniqueActivationId().join());
+        dumpMessages();
+    }
+
     @SuppressWarnings("unused")
     @Test(timeout = 15_000L)
     public void simpleStatelessWorkerDeactivationTest() throws ExecutionException, InterruptedException, TimeoutException

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/SomeActor.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/SomeActor.java
@@ -16,4 +16,6 @@ public interface SomeActor extends Actor
     Task<Boolean> getActivationWasCalled();
 
     Task<String> getNodeId();
+
+    Task setCanBeRemoved(boolean canBeRemoved);
 }

--- a/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/SomeActorImpl.java
+++ b/actors/test/actor-tests/src/test/java/com/ea/orbit/actors/test/actors/SomeActorImpl.java
@@ -10,6 +10,7 @@ public class SomeActorImpl extends AbstractActor implements SomeActor
 {
     private UUID uniqueActivationId = UUID.randomUUID();
     private boolean activationWasCalled;
+    private boolean canBeRemoved = true;
 
     @Override
     public Task<String> sayHello(final String greeting)
@@ -70,5 +71,22 @@ public class SomeActorImpl extends AbstractActor implements SomeActor
     public Task<String> getNodeId()
     {
         return Task.fromValue(runtimeIdentity());
+    }
+
+    @Override
+    public Task setCanBeRemoved(final boolean canBeRemoved)
+    {
+        this.canBeRemoved = canBeRemoved;
+        return Task.done();
+    }
+
+    @Override
+    public Task<Boolean> canBeRemoved(final boolean ttlExpired)
+    {
+        if (!canBeRemoved)
+        {
+            return Task.fromValue(false);
+        }
+        return Task.fromValue(ttlExpired);
     }
 }


### PR DESCRIPTION
…be deactivated.

Motivation:

Last access TTL based deactivation is not suitable in all scenarios.

Modifications:

Add new method to AbstractActor which implementations can override to hint to the system when the actor can be deactivated.

Result:

Better lifetime management of actors.